### PR TITLE
chore: reduce desktop app size

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "npmRebuild": true,
     "generateUpdatesFilesForAllChannels": true,
     "files": [
+      "!node_modules",
       "dist/**/*",
       "dist-electron/**/*",
       "dist-simple/**/*",


### PR DESCRIPTION
Avoid bundle useless node_modules into app

By default, electron-builder will bundle all the deps in `"dependency"` field of `package.json`, most deps are already bundled by vite, so just ignore them