### PR TITLE
refactor(search): Transition from FTS to trigram indexing for documen…

### DIFF
--- a/apps/web-app/hooks/use-space.ts
+++ b/apps/web-app/hooks/use-space.ts
@@ -76,17 +76,13 @@ export const useSpace = () => {
   )
 
   const rebuildIndex = useCallback(async () => {
-    // Rebuild doc FTS index
+    // Rebuild doc trigram index (no longer uses FTS)
     await sqlite?.doc.rebuildIndex({
-      recreateFtsTable: true
+      refillNullMarkdown: true
     })
-    
-    // Rebuild extension FTS index
-    await sqlite?.extension.rebuildFTSIndex({
-      recreateFtsTable: true
-    })
-    
-    console.log('Rebuilt all FTS indexes')
+
+
+    console.log('Rebuilt all indexes')
   }, [sqlite])
 
   const createSpace = useCallback(async (spaceName: string, enableSync: boolean = false, volumeId?: string) => {

--- a/packages/core/meta-table/doc/base.ts
+++ b/packages/core/meta-table/doc/base.ts
@@ -23,10 +23,6 @@ export interface DocMeta {
 
 export class BaseDocTable extends BaseTableImpl<IDoc> implements BaseTable<IDoc> {
   name = DocTableName
-  createFTSSql = this.dataSpace.hasLoadExtension ? `
-  CREATE VIRTUAL TABLE IF NOT EXISTS fts_docs USING fts5(id,markdown, content='${this.name}',tokenize = 'simple');
-  `: `CREATE VIRTUAL TABLE IF NOT EXISTS fts_docs USING fts5(id,markdown, content='${this.name}');`
-
 
   createTableSql = `
   CREATE TABLE IF NOT EXISTS ${this.name} (
@@ -39,26 +35,14 @@ export class BaseDocTable extends BaseTableImpl<IDoc> implements BaseTable<IDoc>
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
   );
 
-
   CREATE TRIGGER IF NOT EXISTS update_time_trigger__${this.name}
   AFTER UPDATE ON ${this.name}
   FOR EACH ROW
   BEGIN
     UPDATE ${this.name} SET updated_at = CURRENT_TIMESTAMP WHERE id = NEW.id;
   END;
-    ${this.createFTSSql}    
-  CREATE TEMP TRIGGER IF NOT EXISTS ${this.name}_ai AFTER INSERT ON ${this.name} BEGIN
-    INSERT INTO fts_docs(rowid,id, markdown) VALUES (new.rowid, new.id, new.markdown);
-  END;
 
-  CREATE TEMP TRIGGER IF NOT EXISTS ${this.name}_ad AFTER DELETE ON ${this.name} BEGIN
-    INSERT INTO fts_docs(fts_docs, rowid, id,markdown) VALUES('delete', old.rowid, old.id, old.markdown);
-  END;
-  
-  CREATE TEMP TRIGGER IF NOT EXISTS ${this.name}_au AFTER UPDATE ON ${this.name} BEGIN
-    INSERT INTO fts_docs(fts_docs, rowid, id, markdown) VALUES('delete', old.rowid, old.id, old.markdown);
-    INSERT INTO fts_docs(rowid, id, markdown) VALUES (new.rowid, new.id, new.markdown);
-  END;
+  CREATE INDEX IF NOT EXISTS idx_${this.name}_markdown_trigram ON ${this.name}(markdown trigram) WHERE markdown IS NOT NULL;
 `
 
 }

--- a/packages/core/meta-table/doc/search.test.ts
+++ b/packages/core/meta-table/doc/search.test.ts
@@ -1,0 +1,273 @@
+import { describe, it, expect } from 'vitest'
+import { performTrigramSearch } from './search'
+
+// Mock DataSpace for testing
+class MockDataSpace {
+  private data: any[] = []
+
+  constructor(data: any[] = []) {
+    this.data = data
+  }
+
+  async exec2(sql: string, params: any[] = []): Promise<any[]> {
+    // Mock the trigram search query behavior
+    if (sql.includes('LIKE') && sql.includes('markdown')) {
+      // For search queries, return data that matches all keywords (AND logic)
+      return this.data.filter(row => {
+        const content = row.markdown || ''
+        // If markdown is null, only return if no keywords (empty search)
+        if (row.markdown === null || row.markdown === undefined) {
+          return params.length === 0
+        }
+        return params.every((param: string) => {
+          const keyword = param.replace(/%/g, '')
+          return content.toLowerCase().includes(keyword.toLowerCase())
+        })
+      }).sort((a, b) => (b.markdown || '').length - (a.markdown || '').length) // Sort by length desc
+        .slice(0, 100) // LIMIT 100
+    }
+
+    // For other queries, return all data
+    return this.data
+  }
+}
+
+describe('performTrigramSearch', () => {
+  describe('keyword highlighting', () => {
+    it('should highlight single keyword', async () => {
+      const mockDataSpace = new MockDataSpace([
+        { id: 1, markdown: 'This is a test document' }
+      ])
+
+      const results = await performTrigramSearch(['test'], {
+        tableName: 'docs',
+        fieldName: 'markdown',
+        highlightTag: 'b',
+        contextLength: 100,
+        dataSpace: mockDataSpace
+      })
+
+      expect(results).toHaveLength(1)
+      expect(results[0].result).toBe('This is a <b>test</b> document')
+    })
+
+    it('should highlight multiple keywords without nesting', async () => {
+      const mockDataSpace = new MockDataSpace([
+        { id: 1, markdown: 'testing functionality' }
+      ])
+
+      const results = await performTrigramSearch(['test', 'est'], {
+        tableName: 'docs',
+        fieldName: 'markdown',
+        highlightTag: 'b',
+        contextLength: 100,
+        dataSpace: mockDataSpace
+      })
+
+      expect(results).toHaveLength(1)
+      // Should highlight matches without creating nested HTML tags
+      // Note: overlapping matches like "test" and "est" in "testing" result in only the first match being highlighted
+      expect(results[0].result).toBe('<b>test</b>ing functionality')
+    })
+
+    it('should highlight overlapping keywords correctly', async () => {
+      const mockDataSpace = new MockDataSpace([
+        { id: 1, markdown: 'The best testing framework' }
+      ])
+
+      const results = await performTrigramSearch(['test', 'est'], {
+        tableName: 'docs',
+        fieldName: 'markdown',
+        highlightTag: 'b',
+        contextLength: 100,
+        dataSpace: mockDataSpace
+      })
+
+      expect(results).toHaveLength(1)
+      // Should highlight "est" in "best" and "test" in "testing" without breaking HTML
+      const result = results[0].result
+      expect(result).toContain('<b>est</b>')
+      expect(result).toContain('<b>test</b>')
+      // Count opening and closing tags should be equal
+      const openTags = (result.match(/<b>/g) || []).length
+      const closeTags = (result.match(/<\/b>/g) || []).length
+      expect(openTags).toBe(closeTags)
+    })
+
+    it('should handle case insensitive matching', async () => {
+      const mockDataSpace = new MockDataSpace([
+        { id: 1, markdown: 'This is a TEST document' }
+      ])
+
+      const results = await performTrigramSearch(['test'], {
+        tableName: 'docs',
+        fieldName: 'markdown',
+        highlightTag: 'b',
+        contextLength: 100,
+        dataSpace: mockDataSpace
+      })
+
+      expect(results).toHaveLength(1)
+      expect(results[0].result).toBe('This is a <b>TEST</b> document')
+    })
+
+    it('should escape special regex characters in keywords', async () => {
+      const mockDataSpace = new MockDataSpace([
+        { id: 1, markdown: 'This has special chars: test.*+?' }
+      ])
+
+      const results = await performTrigramSearch(['test.*+?'], {
+        tableName: 'docs',
+        fieldName: 'markdown',
+        highlightTag: 'b',
+        contextLength: 100,
+        dataSpace: mockDataSpace
+      })
+
+      expect(results).toHaveLength(1)
+      expect(results[0].result).toBe('This has special chars: <b>test.*+?</b>')
+    })
+
+    it('should use different highlight tags', async () => {
+      const mockDataSpace = new MockDataSpace([
+        { id: 1, markdown: 'This is a test document' }
+      ])
+
+      const results = await performTrigramSearch(['test'], {
+        tableName: 'docs',
+        fieldName: 'markdown',
+        highlightTag: 'mark',
+        contextLength: 100,
+        dataSpace: mockDataSpace
+      })
+
+      expect(results).toHaveLength(1)
+      expect(results[0].result).toBe('This is a <mark>test</mark> document')
+    })
+  })
+
+  describe('truncation', () => {
+    it('should truncate long text before applying highlights', async () => {
+      const longText = 'This is a very long document that contains some test content and more text'
+      const mockDataSpace = new MockDataSpace([
+        { id: 1, markdown: longText }
+      ])
+
+      const results = await performTrigramSearch(['test'], {
+        tableName: 'docs',
+        fieldName: 'markdown',
+        highlightTag: 'b',
+        contextLength: 30, // Short context length
+        dataSpace: mockDataSpace
+      })
+
+      expect(results).toHaveLength(1)
+      const result = results[0].result
+      expect(result.length).toBeLessThanOrEqual(33) // 30 + '...'
+      expect(result.endsWith('...')).toBe(true)
+
+      // The truncated text should still have valid HTML
+      const openTags = (result.match(/<b>/g) || []).length
+      const closeTags = (result.match(/<\/b>/g) || []).length
+      expect(openTags).toBe(closeTags)
+    })
+
+    it('should not truncate if text is within context length', async () => {
+      const mockDataSpace = new MockDataSpace([
+        { id: 1, markdown: 'Short test text' }
+      ])
+
+      const results = await performTrigramSearch(['test'], {
+        tableName: 'docs',
+        fieldName: 'markdown',
+        highlightTag: 'b',
+        contextLength: 100,
+        dataSpace: mockDataSpace
+      })
+
+      expect(results).toHaveLength(1)
+      expect(results[0].result).toBe('Short <b>test</b> text')
+      expect(results[0].result.endsWith('...')).toBe(false)
+    })
+
+    it('should handle truncation with multiple keywords', async () => {
+      const longText = 'This document contains testing and best practices for development'
+      const mockDataSpace = new MockDataSpace([
+        { id: 1, markdown: longText }
+      ])
+
+      const results = await performTrigramSearch(['test', 'best'], {
+        tableName: 'docs',
+        fieldName: 'markdown',
+        highlightTag: 'b',
+        contextLength: 40,
+        dataSpace: mockDataSpace
+      })
+
+      expect(results).toHaveLength(1)
+      const result = results[0].result
+      // After highlighting, the result may be longer than contextLength due to HTML tags
+      // The key is that truncation happens before highlighting to avoid breaking tags
+      expect(result.endsWith('...')).toBe(true)
+
+      // HTML should still be valid
+      const openTags = (result.match(/<b>/g) || []).length
+      const closeTags = (result.match(/<\/b>/g) || []).length
+      expect(openTags).toBe(closeTags)
+    })
+  })
+
+  describe('edge cases', () => {
+    it('should handle empty results', async () => {
+      const mockDataSpace = new MockDataSpace([])
+
+      const results = await performTrigramSearch(['test'], {
+        tableName: 'docs',
+        fieldName: 'markdown',
+        highlightTag: 'b',
+        contextLength: 100,
+        dataSpace: mockDataSpace
+      })
+
+      expect(results).toEqual([])
+    })
+
+    it('should handle null or empty markdown field', async () => {
+      const mockDataSpace = new MockDataSpace([
+        { id: 1, markdown: null },
+        { id: 2, markdown: '' },
+        { id: 3, markdown: 'test content' }
+      ])
+
+      const results = await performTrigramSearch(['test'], {
+        tableName: 'docs',
+        fieldName: 'markdown',
+        highlightTag: 'b',
+        contextLength: 100,
+        dataSpace: mockDataSpace
+      })
+
+      // Null values are filtered out by the SQL query (IS NOT NULL condition)
+      // Empty strings that don't contain the keyword are also filtered out
+      expect(results).toHaveLength(1)
+      expect(results[0].result).toBe('<b>test</b> content')
+    })
+
+    it('should handle multiple matches of same keyword', async () => {
+      const mockDataSpace = new MockDataSpace([
+        { id: 1, markdown: 'test test test' }
+      ])
+
+      const results = await performTrigramSearch(['test'], {
+        tableName: 'docs',
+        fieldName: 'markdown',
+        highlightTag: 'b',
+        contextLength: 100,
+        dataSpace: mockDataSpace
+      })
+
+      expect(results).toHaveLength(1)
+      expect(results[0].result).toBe('<b>test</b> <b>test</b> <b>test</b>')
+    })
+  })
+})

--- a/packages/core/meta-table/doc/search.ts
+++ b/packages/core/meta-table/doc/search.ts
@@ -1,5 +1,75 @@
 import type { BaseDocTable } from "./base";
-import { escapeFTSQuery } from "./helper";
+
+// Common search utilities
+export interface SearchOptions {
+  tableName: string;
+  fieldName: string;
+  highlightTag: string; // 'b' for <b> or 'mark' for <mark>
+  contextLength: number; // character limit for result
+  dataSpace: any; // database interface
+  transformResult?: (row: any) => any; // optional result transformation
+}
+
+export async function performTrigramSearch(
+  keywords: string[],
+  options: SearchOptions
+): Promise<any[]> {
+  const { tableName, fieldName, highlightTag, contextLength, dataSpace, transformResult } = options;
+
+  try {
+    // Build LIKE conditions for each keyword (AND logic)
+    const conditions = keywords.map(() => `${fieldName} LIKE ?`).join(" AND ");
+    const params = keywords.map(kw => `%${kw}%`);
+
+    // Build the main search query
+    const sql = `
+      SELECT *, length(${fieldName}) as len
+      FROM ${tableName}
+      WHERE ${conditions} AND ${fieldName} IS NOT NULL
+      ORDER BY len ASC
+      LIMIT 100
+    `;
+
+    const res = await dataSpace.exec2(sql, params);
+
+    // Transform results with keyword highlighting
+    return res.map((row: any) => {
+      let highlightedResult = row[fieldName] || '';
+
+      // Add highlight tags around keywords
+      keywords.forEach(keyword => {
+        // Escape special regex characters and create case-insensitive match
+        const escapedKeyword = keyword.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        const regex = new RegExp(`(${escapedKeyword})`, 'gi');
+        const tagName = highlightTag;
+        highlightedResult = highlightedResult.replace(regex, `<${tagName}>$1</${tagName}>`);
+      });
+
+      // Truncate if too long
+      if (highlightedResult.length > contextLength) {
+        highlightedResult = highlightedResult.substring(0, contextLength) + '...';
+      }
+
+      // Apply custom transformation if provided
+      if (transformResult) {
+        return {
+          ...transformResult(row),
+          result: highlightedResult
+        };
+      }
+
+      // Default result format
+      return {
+        id: row.id,
+        result: highlightedResult
+      };
+    });
+
+  } catch (error) {
+    console.error('Search failed:', error);
+    return [];
+  }
+}
 
 // Mixin to add search-specific methods
 type Constructor<T = {}> = new (...args: any[]) => T & BaseDocTable;
@@ -10,27 +80,9 @@ export function WithSearch<T extends Constructor>(Base: T) {
 
         async rebuildIndex(opts: {
             refillNullMarkdown?: boolean;
-            recreateFtsTable?: boolean;
         }) {
-            const { refillNullMarkdown, recreateFtsTable } = opts;
+            const { refillNullMarkdown } = opts;
 
-            if (recreateFtsTable) {
-                // Drop triggers first
-                await this.dataSpace.db.exec(`
-        DROP TRIGGER IF EXISTS ${this.name}_ai;
-        DROP TRIGGER IF EXISTS ${this.name}_ad;
-        DROP TRIGGER IF EXISTS ${this.name}_au;
-      `);
-                // Then drop the FTS table
-                await this.dataSpace.exec2(`DROP TABLE IF EXISTS fts_docs;`);
-                // Recreate the FTS table
-                await this.dataSpace.exec2(this.createFTSSql);
-                console.log(`Recreated fts_docs table and triggers for ${this.dataSpace.dbName}`);
-            }
-
-            await this.dataSpace.exec2(
-                `INSERT INTO fts_docs(fts_docs) VALUES('rebuild');`
-            )
             if (refillNullMarkdown) {
                 const res = await this.dataSpace.exec2(
                     `SELECT id, markdown FROM ${this.name}`
@@ -51,24 +103,22 @@ export function WithSearch<T extends Constructor>(Base: T) {
                     }
                 }
             }
-            await this.dataSpace.exec2(
-                `INSERT INTO fts_docs(fts_docs) VALUES('rebuild');`
-            )
+
             console.log(`rebuild ${this.dataSpace.dbName} index`)
         }
         /**
-         * Search documents using full-text search with progressive query processing
+         * Search documents using trigram index with LIKE queries for multi-keyword AND search
          *
-         * @param query The search query string
+         * @param query The search query string (space-separated keywords)
          * @param options Optional search configuration (kept for backward compatibility)
          * @returns Array of search results with document ID and highlighted snippets
          *
          * @example
-         * // Basic search
-         * const results = await docTable.search('hello world');
+         * // Basic multi-keyword search (AND logic)
+         * const results = await docTable.search('文件 图片'); // finds docs containing both "文件" and "图片"
          *
-         * // Advanced FTS syntax (automatically detected and handled)
-         * const results = await docTable.search('"exact phrase" AND keyword*');
+         * // Single keyword search
+         * const results = await docTable.search('笔记'); // finds docs containing "笔记"
          */
         async search(query: string, options?: { allowAdvanced?: boolean }): Promise<{ id: string; result: string }[]> {
             if (!query || typeof query !== 'string') {
@@ -80,62 +130,19 @@ export function WithSearch<T extends Constructor>(Base: T) {
                 return [];
             }
 
-            // First try: Use the original query directly (supports advanced FTS syntax)
-            try {
-                const res = await this.dataSpace.exec2(
-                    `SELECT id, snippet(fts_docs, 1, '<b>', '</b>','...',63) as result FROM fts_docs WHERE fts_docs MATCH ?;`,
-                    [trimmedQuery]
-                );
-
-                // If we found results with original query, return them
-                if (res.length > 0) {
-                    return res.reverse();
-                }
-            } catch (error) {
-                console.log('Original query failed, trying escaped version:', error instanceof Error ? error.message : String(error));
+            // Split query into keywords by spaces, filter out empty strings
+            const keywords = trimmedQuery.split(/\s+/).filter(k => k.length > 0);
+            if (keywords.length === 0) {
+                return [];
             }
 
-            // Second try: Use safe escaping (exact phrase match)
-            try {
-                const escapedQuery = escapeFTSQuery(trimmedQuery, false);
-                if (escapedQuery && escapedQuery !== trimmedQuery) {
-                    const res = await this.dataSpace.exec2(
-                        `SELECT id, snippet(fts_docs, 1, '<b>', '</b>','...',63) as result FROM fts_docs WHERE fts_docs MATCH ?;`,
-                        [escapedQuery]
-                    );
-
-                    if (res.length > 0) {
-                        return res.reverse();
-                    }
-                }
-            } catch (error) {
-                console.log('Escaped query also failed:', error instanceof Error ? error.message : String(error));
-            }
-
-            // Third try: If query contains special chars, try a more permissive search by tokenizing
-            if (/[\[\]\(\)\-\+\*\&\|\!\@\#\$\%\^\~]/.test(trimmedQuery)) {
-                try {
-                    // Remove special characters and search for individual words
-                    const cleanQuery = trimmedQuery
-                        .replace(/[\[\]\(\)\-\+\*\&\|\!\@\#\$\%\^\~]/g, ' ')
-                        .replace(/\s+/g, ' ')
-                        .trim();
-
-                    if (cleanQuery) {
-                        console.log('Trying permissive search with:', cleanQuery);
-                        const fallbackRes = await this.dataSpace.exec2(
-                            `SELECT id, snippet(fts_docs, 1, '<b>', '</b>','...',63) as result FROM fts_docs WHERE fts_docs MATCH ?;`,
-                            [cleanQuery]
-                        );
-                        return fallbackRes.reverse();
-                    }
-                } catch (fallbackError) {
-                    console.error('Fallback search also failed:', fallbackError);
-                }
-            }
-
-            // If all searches fail, return empty results instead of throwing
-            return [];
+            return performTrigramSearch(keywords, {
+                tableName: this.name,
+                fieldName: 'markdown',
+                highlightTag: 'b',
+                contextLength: 63,
+                dataSpace: this.dataSpace
+            });
         }
     };
 }

--- a/packages/core/meta-table/doc/search.ts
+++ b/packages/core/meta-table/doc/search.ts
@@ -34,21 +34,24 @@ export async function performTrigramSearch(
 
     // Transform results with keyword highlighting
     return res.map((row: any) => {
-      let highlightedResult = row[fieldName] || '';
+      const originalText = row[fieldName] || '';
 
-      // Add highlight tags around keywords
-      keywords.forEach(keyword => {
-        // Escape special regex characters and create case-insensitive match
-        const escapedKeyword = keyword.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-        const regex = new RegExp(`(${escapedKeyword})`, 'gi');
-        const tagName = highlightTag;
-        highlightedResult = highlightedResult.replace(regex, `<${tagName}>$1</${tagName}>`);
-      });
+      // Truncate the original text first to avoid breaking HTML tags
+      const truncatedText = originalText.length > contextLength
+        ? originalText.substring(0, contextLength) + '...'
+        : originalText;
 
-      // Truncate if too long
-      if (highlightedResult.length > contextLength) {
-        highlightedResult = highlightedResult.substring(0, contextLength) + '...';
-      }
+      // Apply keyword highlighting to the truncated text
+      let highlightedResult = truncatedText;
+
+      // Create a regex that matches any of the keywords (case-insensitive)
+      const keywordPatterns = keywords.map(keyword =>
+        keyword.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+      );
+      const combinedRegex = new RegExp(`(${keywordPatterns.join('|')})`, 'gi');
+
+      // Replace all matches with highlighted versions
+      highlightedResult = highlightedResult.replace(combinedRegex, `<${highlightTag}>$1</${highlightTag}>`);
 
       // Apply custom transformation if provided
       if (transformResult) {

--- a/packages/core/meta-table/extension.ts
+++ b/packages/core/meta-table/extension.ts
@@ -14,6 +14,7 @@ import { BlockExtensionType } from "../types/IExtension";
 
 import type { BaseTable } from "./base";
 import { BaseTableImpl } from "./base";
+import { performTrigramSearch } from "./doc/search";
 
 // Re-export types for backward compatibility
 export type { ExtensionStatus, IExtension, TableViewMeta };
@@ -43,10 +44,6 @@ export class ExtensionTable
   extends BaseTableImpl<IExtension>
   implements BaseTable<IExtension> {
   name = ExtensionTableName
-  
-  createFTSSql = this.dataSpace.hasLoadExtension ? `
-  CREATE VIRTUAL TABLE IF NOT EXISTS fts_extensions USING fts5(id, slug, description, ts_code, content='${this.name}', tokenize='simple');
-  ` : `CREATE VIRTUAL TABLE IF NOT EXISTS fts_extensions USING fts5(id, slug, description, ts_code, content='${this.name}');`
 
   createTableSql = `
     CREATE TABLE IF NOT EXISTS ${this.name} (
@@ -74,28 +71,12 @@ export class ExtensionTable
       UPDATE ${this.name} SET updated_at = CURRENT_TIMESTAMP WHERE id = NEW.id;
     END;
 
-    ${this.createFTSSql}
-
-    CREATE TEMP TRIGGER IF NOT EXISTS ${this.name}_fts_ai AFTER INSERT ON ${this.name} BEGIN
-      INSERT INTO fts_extensions(rowid, id, slug, description, ts_code) 
-      VALUES (new.rowid, new.id, new.slug, new.description, new.ts_code);
-    END;
-
-    CREATE TEMP TRIGGER IF NOT EXISTS ${this.name}_fts_ad AFTER DELETE ON ${this.name} BEGIN
-      INSERT INTO fts_extensions(fts_extensions, rowid, id, slug, description, ts_code) 
-      VALUES('delete', old.rowid, old.id, old.slug, old.description, old.ts_code);
-    END;
-
-    CREATE TEMP TRIGGER IF NOT EXISTS ${this.name}_fts_au AFTER UPDATE ON ${this.name} BEGIN
-      INSERT INTO fts_extensions(fts_extensions, rowid, id, slug, description, ts_code) 
-      VALUES('delete', old.rowid, old.id, old.slug, old.description, old.ts_code);
-      INSERT INTO fts_extensions(rowid, id, slug, description, ts_code) 
-      VALUES (new.rowid, new.id, new.slug, new.description, new.ts_code);
-    END;
 
     ${createAllTriggersForFields(this.name, [
     'id', 'slug', 'name', 'type', 'code', 'enabled', 'icon', 'meta'
   ])}
+
+    CREATE INDEX IF NOT EXISTS idx_${this.name}_ts_code_trigram ON ${this.name}(ts_code) WHERE ts_code IS NOT NULL;
 `
 
   JSONFields: string[] = [
@@ -485,85 +466,34 @@ export class ExtensionTable
   }
 
   /**
-   * Full-text search extensions by slug, description, and code
+   * Full-text search extensions by code using trigram + LIKE
    */
   async fullTextSearchExtensions(query: string): Promise<Array<IExtension & { result?: string }>> {
-    const sql = `
-      SELECT e.*, snippet(fts_extensions, -1, '<mark>', '</mark>', '...', 64) as result
-      FROM fts_extensions 
-      JOIN ${this.name} e ON fts_extensions.id = e.id
-      WHERE fts_extensions MATCH ?
-      ORDER BY rank
-    `
-    const res = await this.dataSpace.exec2(sql, [query])
-    return res.map((item: any) => {
-      const extension = this.toJson(item)
-      return {
-        ...extension,
-        result: item.result
-      }
-    })
-  }
-
-  /**
-   * Rebuild FTS index for all existing extensions
-   * This should be called once for migration when FTS is first introduced
-   * 
-   * @param opts Options for rebuilding
-   * @param opts.recreateFtsTable If true, drops and recreates the FTS table and triggers
-   */
-  async rebuildFTSIndex(opts?: { recreateFtsTable?: boolean }): Promise<void> {
-    const { recreateFtsTable = false } = opts || {}
-    
-    try {
-      if (recreateFtsTable) {
-        // Drop triggers first
-        await this.dataSpace.db.exec(`
-          DROP TRIGGER IF EXISTS ${this.name}_fts_ai;
-          DROP TRIGGER IF EXISTS ${this.name}_fts_ad;
-          DROP TRIGGER IF EXISTS ${this.name}_fts_au;
-        `)
-        
-        // Then drop the FTS table
-        await this.dataSpace.exec2(`DROP TABLE IF EXISTS fts_extensions;`)
-        
-        // Recreate the FTS table
-        await this.dataSpace.exec2(this.createFTSSql)
-        
-        // Recreate triggers by re-running the create table SQL
-        // The triggers are created as part of createTableSql
-        await this.dataSpace.db.exec(`
-          CREATE TEMP TRIGGER IF NOT EXISTS ${this.name}_fts_ai AFTER INSERT ON ${this.name} BEGIN
-            INSERT INTO fts_extensions(rowid, id, slug, description, ts_code) 
-            VALUES (new.rowid, new.id, new.slug, new.description, new.ts_code);
-          END;
-
-          CREATE TEMP TRIGGER IF NOT EXISTS ${this.name}_fts_ad AFTER DELETE ON ${this.name} BEGIN
-            INSERT INTO fts_extensions(fts_extensions, rowid, id, slug, description, ts_code) 
-            VALUES('delete', old.rowid, old.id, old.slug, old.description, old.ts_code);
-          END;
-
-          CREATE TEMP TRIGGER IF NOT EXISTS ${this.name}_fts_au AFTER UPDATE ON ${this.name} BEGIN
-            INSERT INTO fts_extensions(fts_extensions, rowid, id, slug, description, ts_code) 
-            VALUES('delete', old.rowid, old.id, old.slug, old.description, old.ts_code);
-            INSERT INTO fts_extensions(rowid, id, slug, description, ts_code) 
-            VALUES (new.rowid, new.id, new.slug, new.description, new.ts_code);
-          END;
-        `)
-        
-        console.log(`Recreated fts_extensions table and triggers for ${this.dataSpace.dbName}`)
-      }
-      
-      // Use FTS5 'rebuild' command to rebuild the index
-      // This is the recommended way for content tables
-      await this.dataSpace.exec2(`INSERT INTO fts_extensions(fts_extensions) VALUES('rebuild')`)
-      
-      console.log(`Rebuilt FTS index for extensions in ${this.dataSpace.dbName}`)
-    } catch (error) {
-      console.error('Failed to rebuild FTS index for extensions:', error)
-      throw error
+    if (!query || typeof query !== 'string') {
+      return [];
     }
+
+    const trimmedQuery = query.trim();
+    if (!trimmedQuery) {
+      return [];
+    }
+
+    // Split query into keywords by spaces, filter out empty strings
+    const keywords = trimmedQuery.split(/\s+/).filter(k => k.length > 0);
+    if (keywords.length === 0) {
+      return [];
+    }
+
+    return performTrigramSearch(keywords, {
+      tableName: this.name,
+      fieldName: 'ts_code',
+      highlightTag: 'b',
+      contextLength: 64,
+      dataSpace: this.dataSpace,
+      transformResult: (row: any) => this.toJson(row)
+    });
   }
+
 
   /**
    * Get extensions with bindings


### PR DESCRIPTION
…t and extension searches, enhancing performance and simplifying index management

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches document and extension search from FTS to trigram + LIKE with highlighting, adds indexes and tests, and updates rebuild logic.
> 
> - **Core/Search**:
>   - **Docs**:
>     - Remove FTS virtual table/triggers and related rebuild logic in `packages/core/meta-table/doc/*`.
>     - Add trigram index: `CREATE INDEX idx_docs_markdown_trigram ON docs(markdown trigram) WHERE markdown IS NOT NULL`.
>     - Implement `performTrigramSearch` with multi-keyword AND search, truncation, and highlighting; update `search()` to use it.
>     - Add comprehensive tests in `packages/core/meta-table/doc/search.test.ts`.
>   - **Extensions**:
>     - Remove FTS definitions/triggers and FTS rebuild method from `packages/core/meta-table/extension.ts`.
>     - Add trigram index on `ts_code` and update `fullTextSearchExtensions()` to use `performTrigramSearch` with highlighting.
> - **Web**:
>   - Update `apps/web-app/hooks/use-space.ts` `rebuildIndex()` to rebuild doc trigram index with `refillNullMarkdown` and adjust log message.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 196c52fd05b2678c63e3af15fab711600e632dd5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->