### PR TITLE
Eidos graft init command

### DIFF
--- a/apps/cli/GRAFT_IMPLEMENTATION.md
+++ b/apps/cli/GRAFT_IMPLEMENTATION.md
@@ -1,0 +1,213 @@
+# Graft Init Command Implementation
+
+## Overview
+
+Implemented `eidos graft init` command in the CLI to convert Eidos spaces to use graft storage format for remote synchronization.
+
+## What Was Implemented
+
+### 1. New Command File: `src/commands/graft.ts`
+
+**Main Function:** `graftInitCommand(options: GraftInitOptions)`
+
+**Key Features:**
+- Validates the space exists and has a valid database
+- Accepts credentials via command-line options or environment variables
+- Loads the graft SQLite extension
+- Creates a new graft volume using `PRAGMA graft_new`
+- Imports existing `db.sqlite3` data using `PRAGMA graft_import`
+- Creates `graft.toml` configuration file
+- Updates `~/.eidos/spaces.json` with volumeId
+
+**Process Flow:**
+```
+1. Validate space path and database existence
+2. Get S3 credentials (from options or env vars)
+3. Create .eidos/.graft directory
+4. Generate graft.toml configuration
+5. Set environment variables (GRAFT_CONFIG, AWS_*)
+6. Open database with graft VFS (file:main?vfs=graft)
+7. Load graft extension
+8. Execute PRAGMA graft_new → get volumeId
+9. Execute PRAGMA graft_import → import existing data
+10. Update space registry with volumeId
+```
+
+### 2. CLI Integration: `src/index.ts`
+
+Added graft command with subcommand structure:
+```bash
+eidos graft init [path] [options]
+```
+
+**Options:**
+- `-r, --remote <url>` - Remote graft URL
+- `--access-key-id <key>` - AWS access key ID
+- `--secret-access-key <key>` - AWS secret access key
+- `--bucket-name <name>` - S3 bucket name (default: eidos-sync)
+- `--endpoint <url>` - S3 endpoint URL (default: https://s3.eidos.space)
+
+### 3. Package Dependencies: `package.json`
+
+Added required dependencies:
+- `better-sqlite3` - For SQLite database operations with extension support
+- `@eidos.space/sync` - For graft helper functions (parseGraftNew)
+
+### 4. Documentation: `README.md`
+
+Added comprehensive documentation including:
+- Command usage examples
+- Credential configuration options
+- What the command does
+- Post-initialization next steps
+
+## Key Implementation Details
+
+### Graft Configuration File Format
+
+```toml
+data_dir = "/path/to/space/.eidos/.graft"
+[remote]
+type = "s3_compatible"
+bucket = "eidos-sync"
+prefix = "space-id"
+```
+
+### Space Registry Update
+
+The command updates `~/.eidos/spaces.json` with:
+```json
+{
+  "spaces": [
+    {
+      "id": "space-id",
+      "name": "Space Name",
+      "path": "/path/to/space",
+      "sync": {
+        "enabled": true,
+        "remote": "https://eidos.space/username/space-id.graft",
+        "volumeId": "74ggdmAVtx-3CLG4igbxFLAr"
+      }
+    }
+  ]
+}
+```
+
+### Environment Variables
+
+The command sets these environment variables during execution:
+- `GRAFT_CONFIG` - Path to graft.toml
+- `AWS_ACCESS_KEY_ID` - S3 access key
+- `AWS_SECRET_ACCESS_KEY` - S3 secret key
+- `AWS_REGION` - Set to "auto"
+- `AWS_ENDPOINT` - S3 endpoint URL
+
+### Error Handling
+
+The implementation includes comprehensive error handling for:
+- Invalid or non-existent space paths
+- Missing database files
+- Missing credentials
+- Extension loading failures
+- Database operation failures
+- Space registry update failures
+
+## Usage Examples
+
+### Basic Usage
+
+```bash
+# Initialize graft in current directory
+cd /path/to/space
+eidos graft init
+```
+
+### With Explicit Credentials
+
+```bash
+eidos graft init \
+  --access-key-id YOUR_KEY \
+  --secret-access-key YOUR_SECRET \
+  --bucket-name eidos-sync \
+  --endpoint https://s3.eidos.space
+```
+
+### Using Environment Variables
+
+```bash
+export AWS_ACCESS_KEY_ID=your_key
+export AWS_SECRET_ACCESS_KEY=your_secret
+export AWS_BUCKET_NAME=eidos-sync
+export AWS_ENDPOINT=https://s3.eidos.space
+
+eidos graft init /path/to/space
+```
+
+### With Remote URL
+
+```bash
+eidos graft init /path/to/space \
+  --remote https://eidos.space/username/my-space.graft
+```
+
+## Comparison with Desktop App
+
+The desktop app's `GraftDb.convertToGraft()` method has a different purpose:
+- **Desktop App**: Converts an existing space to use graft storage on next open
+- **CLI Command**: Immediately converts the space and initializes graft storage
+
+The CLI implementation follows the pattern used in the desktop app's `NodeServerDatabase` initialization (sqlite-server/index.ts), which:
+1. Calls `PRAGMA graft_new` to create a volume
+2. Calls `PRAGMA graft_import` to import existing data
+3. Stores the volumeId in the space configuration
+
+## Files Modified/Created
+
+### Created:
+- `/workspace/apps/cli/src/commands/graft.ts` - Main graft command implementation
+
+### Modified:
+- `/workspace/apps/cli/src/index.ts` - Added graft command registration
+- `/workspace/apps/cli/package.json` - Added dependencies
+- `/workspace/apps/cli/README.md` - Added documentation
+
+## Future Enhancements
+
+Potential future additions to the graft command:
+- `eidos graft status` - Check sync status
+- `eidos graft push` - Push local changes to remote
+- `eidos graft pull` - Pull remote changes
+- `eidos graft fetch` - Fetch remote changes without merging
+- `eidos graft checkout` - Convert back from graft to regular db.sqlite3
+
+## Testing Checklist
+
+To test the implementation:
+- [ ] Run `eidos graft init` in a valid Eidos space
+- [ ] Verify `graft.toml` is created in `.eidos/` directory
+- [ ] Verify `.graft/` directory is created
+- [ ] Verify `spaces.json` is updated with volumeId
+- [ ] Check that existing data is preserved after conversion
+- [ ] Test with explicit credentials via command-line options
+- [ ] Test with credentials from environment variables
+- [ ] Test error handling with invalid paths
+- [ ] Test error handling with missing credentials
+
+## Notes
+
+1. **Extension Requirement**: The graft extension (`libgraft.dylib`/`.so`/`.dll`) must be available in the `dist-sqlite-ext` directory. Run `bun run setup` to download it.
+
+2. **Database Lock**: Ensure the database is not open in other applications (desktop app, other CLI instances) before running the command.
+
+3. **WAL Checkpoint**: The command performs a WAL checkpoint on the existing database before conversion to ensure all data is persisted.
+
+4. **Credentials Security**: Credentials are passed as environment variables to the graft extension. Consider using a secure credential storage mechanism in the future.
+
+5. **Remote URL Format**: The remote URL should follow the format: `https://eidos.space/username/space-id.graft`
+
+## References
+
+- Desktop graft implementation: `apps/desktop/electron/sync/graft-db.ts`
+- Desktop sqlite server: `apps/desktop/electron/sqlite-server/index.ts`
+- Graft helpers: `packages/sync/graft/helpers.ts`
+- Space registry: `packages/space-manager/src/space-registry.ts`

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -23,6 +23,7 @@ Eidos CLI is a **headless version of Eidos** that runs entirely from the command
 - 🌐 **Serve** - Run local API server for any space
 - 💻 **Open** - Open spaces in desktop app (like `code .`)
 - 📦 **Manage** - List and manage all your spaces
+- 🔄 **Graft** - Initialize graft storage for remote syncing
 - 🔗 **Mount** - Mount external directories for file access
 
 ## Quick Start
@@ -144,6 +145,51 @@ eidos open /path/to/space
 - Space must be initialized (contains `.eidos/` directory)
 - Space must be registered in global config
 - Eidos desktop app must be installed
+
+### 🔄 Initialize Graft Storage for Syncing
+
+Convert a space to use graft storage format for remote syncing:
+
+```bash
+# Initialize graft storage in current space
+eidos graft init
+
+# Initialize with explicit credentials
+eidos graft init --access-key-id YOUR_KEY \
+                 --secret-access-key YOUR_SECRET \
+                 --bucket-name eidos-sync \
+                 --endpoint https://s3.eidos.space
+
+# Initialize specific space with remote URL
+eidos graft init /path/to/space \
+                 --remote https://eidos.space/username/space-id.graft
+```
+
+**What it does:**
+
+- Converts `db.sqlite3` to `.graft` storage format
+- Creates `graft.toml` configuration file
+- Imports existing database data into graft storage
+- Registers `volumeId` in space configuration (`~/.eidos/spaces.json`)
+- Enables remote synchronization capabilities
+
+**Credentials:**
+
+You can provide S3-compatible storage credentials via:
+- Command-line options (shown above)
+- Environment variables:
+  ```bash
+  export AWS_ACCESS_KEY_ID=your_key
+  export AWS_SECRET_ACCESS_KEY=your_secret
+  export AWS_BUCKET_NAME=eidos-sync
+  export AWS_ENDPOINT=https://s3.eidos.space
+  ```
+
+**After initialization:**
+
+The space is ready for syncing with remote storage. Your data is stored in:
+- `.eidos/graft.toml` - Configuration file
+- `.eidos/.graft/` - Graft storage directory
 
 ### 🔗 Mount External Directories
 
@@ -361,6 +407,7 @@ apps/cli/
 │   │   ├── init.ts       # Space initialization
 │   │   ├── serve.ts      # API server
 │   │   ├── open.ts       # Open in desktop app
+│   │   ├── graft.ts      # Graft storage initialization
 │   │   ├── mount.ts      # Mount external directories
 │   │   ├── unmount.ts    # Remove mounts
 │   │   └── install.ts    # Installation management

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -25,6 +25,8 @@
   "dependencies": {
     "@eidos.space/core": "workspace:*",
     "@eidos.space/space-manager": "workspace:*",
+    "@eidos.space/sync": "workspace:*",
+    "better-sqlite3": "^11.8.1",
     "commander": "^12.0.0",
     "hono": "^4.5.0"
   },

--- a/apps/cli/src/commands/graft.ts
+++ b/apps/cli/src/commands/graft.ts
@@ -1,0 +1,264 @@
+import path from 'path';
+import fs from 'fs';
+import os from 'os';
+import Database from 'better-sqlite3';
+import { getExtensionPaths } from '../utils/extensions';
+import { logger } from '../utils/logger';
+import { parseGraftNew } from '@/packages/sync/graft/helpers';
+import { getSpaceRegistry } from '@eidos.space/space-manager';
+
+export interface GraftInitOptions {
+  path?: string;
+  remote?: string;
+  accessKeyId?: string;
+  secretAccessKey?: string;
+  bucketName?: string;
+  endpoint?: string;
+}
+
+interface SyncCredentials {
+  bucketName: string;
+  accessKeyId: string;
+  secretAccessKey: string;
+  endpoint: string;
+}
+
+/**
+ * Apply Graft Config to Environment
+ */
+function applyGraftConfigToEnv(spacePath: string, remoteSpaceId: string, credentials: SyncCredentials) {
+  try {
+    const graftConfigPath = path.join(spacePath, '.eidos', 'graft.toml');
+    const graftDirPath = path.join(spacePath, '.eidos', '.graft');
+    
+    // Ensure .graft directory exists
+    if (!fs.existsSync(graftDirPath)) {
+      fs.mkdirSync(graftDirPath, { recursive: true });
+      logger.info(`Created graft directory: ${graftDirPath}`);
+    }
+
+    // Create graft.toml config file
+    const graftConfig = `
+data_dir = "${graftDirPath.replace(/\\/g, '/')}"
+[remote]
+type = "s3_compatible"
+bucket = "${credentials.bucketName}"
+prefix = "${remoteSpaceId}"
+
+# Configure your S3-compatible storage credentials here
+# bucket: Your S3 bucket name
+# prefix: Optional path prefix within the bucket
+`;
+
+    fs.writeFileSync(graftConfigPath, graftConfig, 'utf-8');
+    logger.info(`Created graft config at: ${graftConfigPath}`);
+
+    // Set environment variables
+    process.env.GRAFT_CONFIG = graftConfigPath;
+    process.env.AWS_ACCESS_KEY_ID = credentials.accessKeyId;
+    process.env.AWS_SECRET_ACCESS_KEY = credentials.secretAccessKey;
+    process.env.AWS_REGION = 'auto';
+    process.env.AWS_ENDPOINT = credentials.endpoint;
+
+    logger.info(`Set GRAFT_CONFIG=${graftConfigPath}`);
+    logger.info(`Set AWS_ACCESS_KEY_ID=${credentials.accessKeyId}`);
+    logger.info(`Set AWS_REGION=auto`);
+    logger.info(`Set AWS_ENDPOINT=${credentials.endpoint}`);
+  } catch (error: any) {
+    throw new Error(`Failed to apply graft config: ${error.message}`);
+  }
+}
+
+/**
+ * Register Graft VFS
+ */
+function registerGraftVFS(db: Database.Database, graftLibPath: string): void {
+  try {
+    db.loadExtension(graftLibPath);
+    logger.info('Loaded graft extension successfully');
+  } catch (err: any) {
+    throw new Error(`Failed to load graft VFS extension from ${graftLibPath}: ${err.message}`);
+  }
+}
+
+/**
+ * Get sync credentials from environment variables or command options
+ */
+function getSyncCredentials(options: GraftInitOptions): SyncCredentials {
+  const accessKeyId = options.accessKeyId || process.env.AWS_ACCESS_KEY_ID;
+  const secretAccessKey = options.secretAccessKey || process.env.AWS_SECRET_ACCESS_KEY;
+  const bucketName = options.bucketName || process.env.AWS_BUCKET_NAME || 'eidos-sync';
+  const endpoint = options.endpoint || process.env.AWS_ENDPOINT || 'https://s3.eidos.space';
+
+  if (!accessKeyId || !secretAccessKey) {
+    throw new Error(
+      'Sync credentials not found. Please provide credentials via options or environment variables:\n' +
+      '  --access-key-id <key>     or AWS_ACCESS_KEY_ID\n' +
+      '  --secret-access-key <key> or AWS_SECRET_ACCESS_KEY\n' +
+      '  --bucket-name <name>      or AWS_BUCKET_NAME (optional, defaults to "eidos-sync")\n' +
+      '  --endpoint <url>          or AWS_ENDPOINT (optional, defaults to "https://s3.eidos.space")'
+    );
+  }
+
+  return {
+    accessKeyId,
+    secretAccessKey,
+    bucketName,
+    endpoint,
+  };
+}
+
+/**
+ * Initialize Graft storage for a space
+ * Converts db.sqlite3 to .graft storage format
+ */
+export async function graftInitCommand(options: GraftInitOptions = {}) {
+  try {
+    // Determine target path
+    const targetPath = options.path ? path.resolve(options.path) : process.cwd();
+    const eidosPath = path.join(targetPath, '.eidos');
+    const dbPath = path.join(eidosPath, 'db.sqlite3');
+
+    logger.info(`Initializing graft storage for space at: ${targetPath}`);
+
+    // Validate that this is an Eidos space
+    if (!fs.existsSync(eidosPath)) {
+      logger.error(`Not an Eidos space: ${targetPath}`);
+      logger.info('Please run "eidos init" first to initialize a space.');
+      process.exit(1);
+    }
+
+    if (!fs.existsSync(dbPath)) {
+      logger.error(`Database not found: ${dbPath}`);
+      logger.info('Please ensure the space is properly initialized.');
+      process.exit(1);
+    }
+
+    // Get sync credentials
+    const credentials = getSyncCredentials(options);
+
+    // Determine remote space ID from remote URL or generate one
+    let remoteSpaceId: string;
+    if (options.remote) {
+      const remoteMatch = options.remote.split('/').pop()?.split('.')[0];
+      if (!remoteMatch) {
+        logger.error(`Invalid remote URL: ${options.remote}`);
+        logger.info('Remote URL should be like: https://eidos.space/username/space-id.graft');
+        process.exit(1);
+      }
+      remoteSpaceId = remoteMatch;
+    } else {
+      // Generate remote space ID from space name
+      const spaceName = path.basename(targetPath);
+      remoteSpaceId = spaceName.toLowerCase().replace(/[^a-z0-9-]/g, '-');
+      logger.info(`Using generated remote space ID: ${remoteSpaceId}`);
+    }
+
+    // Apply graft configuration
+    applyGraftConfigToEnv(targetPath, remoteSpaceId, credentials);
+
+    // Get extension paths
+    const extensions = getExtensionPaths();
+    if (!fs.existsSync(extensions.graft.libPath)) {
+      logger.error(`Graft extension not found: ${extensions.graft.libPath}`);
+      logger.info('Please run "bun run setup" to download the required extensions.');
+      process.exit(1);
+    }
+
+    // Initialize database connection with graft VFS
+    logger.info('Opening database with graft VFS...');
+    const db = new Database('file:main?vfs=graft');
+
+    try {
+      // Register graft VFS extension
+      registerGraftVFS(db, extensions.graft.libPath);
+
+      // Checkpoint WAL before conversion
+      if (fs.existsSync(dbPath)) {
+        const tempDb = new Database(dbPath);
+        try {
+          tempDb.exec('PRAGMA wal_checkpoint(TRUNCATE)');
+          logger.info('WAL checkpoint completed');
+        } finally {
+          tempDb.close();
+        }
+      }
+
+      // Initialize a new graft volume
+      logger.info('Creating new graft volume...');
+      const parsedRes = db.pragma('graft_new');
+      const graftInfo = parseGraftNew(parsedRes);
+      
+      if (!graftInfo?.volumeId) {
+        throw new Error('Failed to create graft volume: No volumeId returned');
+      }
+
+      logger.log(`\n✨ Graft volume created successfully!`);
+      logger.log(`  Volume ID: ${graftInfo.volumeId}`);
+      if (graftInfo.localLog) {
+        logger.log(`  Local Log: ${graftInfo.localLog}`);
+      }
+      if (graftInfo.remoteLog) {
+        logger.log(`  Remote Log: ${graftInfo.remoteLog}`);
+      }
+
+      // Import existing database if it exists
+      if (fs.existsSync(dbPath)) {
+        logger.info(`\nImporting existing database from: ${dbPath}`);
+        db.pragma(`graft_import = "${dbPath}";`);
+        logger.log('✓ Database imported successfully');
+      }
+
+      // Update spaces.json with volumeId
+      try {
+        const registry = getSpaceRegistry();
+        const spaces = registry.getAllSpaces();
+        const space = spaces.find(s => s.path === targetPath);
+
+        if (space) {
+          const remoteUrl = options.remote || `https://eidos.space/${os.userInfo().username}/${remoteSpaceId}.graft`;
+          
+          registry.setSpaceSync(space.id, {
+            enabled: true,
+            remote: remoteUrl,
+            volumeId: graftInfo.volumeId,
+          });
+
+          logger.log(`\n✓ Updated space registry with volumeId`);
+          logger.log(`  Space ID: ${space.id}`);
+          logger.log(`  Remote URL: ${remoteUrl}`);
+        } else {
+          logger.warn(`\nSpace not found in registry. You may need to register it first.`);
+          logger.info(`Run: eidos init ${targetPath}`);
+        }
+      } catch (error: any) {
+        logger.warn(`Failed to update space registry: ${error.message}`);
+        logger.info('You may need to manually update ~/.eidos/spaces.json');
+      }
+
+      logger.log(`\n✨ Graft initialization completed successfully!`);
+      logger.log(`\nGraft storage location:`);
+      logger.log(`  Config: ${path.join(eidosPath, 'graft.toml')}`);
+      logger.log(`  Data: ${path.join(eidosPath, '.graft')}`);
+      logger.log(`\nYou can now use graft commands to sync your data:`);
+      logger.log(`  - graft push: Push local changes to remote`);
+      logger.log(`  - graft pull: Pull remote changes to local`);
+      logger.log(`  - graft status: Check sync status`);
+
+    } finally {
+      // Close database connection
+      if (db.open) {
+        db.close();
+      }
+    }
+
+    process.exit(0);
+
+  } catch (error: any) {
+    logger.error(`Failed to initialize graft storage: ${error.message}`);
+    if (error.stack) {
+      logger.info(`\nDetails:\n${error.stack}`);
+    }
+    process.exit(1);
+  }
+}

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -7,6 +7,7 @@ import { openCommand } from './commands/open';
 import { installCommand, uninstallCommand, statusCommand } from './commands/install';
 import { mountCommand } from './commands/mount';
 import { unmountCommand } from './commands/unmount';
+import { graftInitCommand } from './commands/graft';
 
 const program = new Command();
 
@@ -87,6 +88,33 @@ program
   .argument('<name>', 'mount name to remove')
   .action(async (name: string) => {
     await unmountCommand(name);
+  });
+
+// Graft command
+const graftCommand = program
+  .command('graft')
+  .description('Graft storage management commands');
+
+graftCommand
+  .command('init')
+  .description('Initialize graft storage for syncing')
+  .argument('[path]', 'Path to the space (defaults to current directory)')
+  .option('-r, --remote <url>', 'Remote graft URL (e.g., https://eidos.space/username/space.graft)')
+  .option('--access-key-id <key>', 'AWS access key ID')
+  .option('--secret-access-key <key>', 'AWS secret access key')
+  .option('--bucket-name <name>', 'S3 bucket name (default: eidos-sync)')
+  .option('--endpoint <url>', 'S3 endpoint URL (default: https://s3.eidos.space)')
+  .action(async (targetPath?: string, options?: {
+    remote?: string;
+    accessKeyId?: string;
+    secretAccessKey?: string;
+    bucketName?: string;
+    endpoint?: string;
+  }) => {
+    await graftInitCommand({
+      path: targetPath,
+      ...options,
+    });
   });
 
 // Default action: if a single argument is provided without a command, treat it as 'open'


### PR DESCRIPTION
Implement `eidos graft init` command in the CLI to convert `db.sqlite3` to `.graft` storage and enable remote synchronization.

---
<a href="https://cursor.com/background-agent?bcId=bc-628eea09-dc0d-4c3a-8f57-0c58f16063cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-628eea09-dc0d-4c3a-8f57-0c58f16063cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

