### PR TITLE
chore(graft): use Remote 0.2.0 and SDK 0.3.1

### DIFF
--- a/apps/eidos-lite-desktop/README.md
+++ b/apps/eidos-lite-desktop/README.md
@@ -89,7 +89,7 @@ credentials. The titlebar and Sync panel expose queued, running, retry-wait,
 and paused states. Local-only Spaces still neither log in nor create a Sync
 queue.
 
-Graft runs through the published `@eidos.space/graft@0.3.0` Node-API SDK.
+Graft runs through the published `@eidos.space/graft@0.3.1` Node-API SDK.
 Opening a Space does not open or classify its repository. The root Explorer and
 local Eidos File runtime become usable first; the first background or explicit
 version operation lazily starts one Electron utility process and retains one

--- a/apps/eidos-lite-desktop/docs/ARCHITECTURE.md
+++ b/apps/eidos-lite-desktop/docs/ARCHITECTURE.md
@@ -64,7 +64,7 @@ flowchart LR
   F1 -->|"guarded native SQLite handle"| E1["a.eidos"]
   F2 -->|"guarded native SQLite handle"| E2["nested/b.eidos"]
   M -->|"typed private IPC; one process per Space"| G["Graft utility process"]
-  G -->|"one retained RepositorySession"| N["Official Node-API SDK 0.3.0"]
+  G -->|"one retained RepositorySession"| N["Official Node-API SDK 0.3.1"]
   N --> S["whole ordinary folder Space"]
   N -. "explicit in-memory credential; Sync/Clone only" .-> H["Selected official Hosted Remote"]
 ```
@@ -311,7 +311,7 @@ SDK session transport at construction. Status, diff, history, checkpoint,
 restore, push, and clone never create a CLI subprocess; Lite has no backend
 switch, executable lookup, or CLI credential environment path.
 
-The SDK adapter pins published `@eidos.space/graft@0.3.0`,
+The SDK adapter pins published `@eidos.space/graft@0.3.1`,
 lazily opens one session on the first background or explicit repository read,
 and closes it when the window closes. It asks the published
 `operationMaterializesWorktree()` contract before restore. Remote credentials

--- a/apps/eidos-lite-desktop/docs/OPERATIONS.md
+++ b/apps/eidos-lite-desktop/docs/OPERATIONS.md
@@ -186,7 +186,7 @@ sequence.
 
 ## Stable Graft supply chain
 
-The runtime pins published `@eidos.space/graft@0.3.0`; npm selects one of its
+The runtime pins published `@eidos.space/graft@0.3.1`; npm selects one of its
 five exact-version optional native packages for the current platform. Packaging
 keeps the JavaScript wrapper in ASAR and unpacks only the selected native
 package; `graft-worker.js` loads it directly in an Electron

--- a/apps/eidos-lite-desktop/package.json
+++ b/apps/eidos-lite-desktop/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@eidos.space/eidos-file": "workspace:*",
     "@eidos.space/eidos-file-ui": "workspace:*",
-    "@eidos.space/graft": "0.3.0",
+    "@eidos.space/graft": "0.3.1",
     "@glideapps/glide-data-grid": "^6.0.0",
     "@pierre/diffs": "1.2.7",
     "@pierre/trees": "1.0.0-beta.5",

--- a/apps/eidos-lite-desktop/scripts/packaged-smoke.mjs
+++ b/apps/eidos-lite-desktop/scripts/packaged-smoke.mjs
@@ -231,7 +231,7 @@ try {
     ) ||
     !report.graft?.available ||
     report.graft?.backend !== "sdk" ||
-    report.graft?.version !== "0.3.0" ||
+    report.graft?.version !== "0.3.1" ||
     report.mutation?.afterInsertCount !== report.mutation?.beforeCount + 1 ||
     report.mutation?.afterDeleteCount !== report.mutation?.beforeCount ||
     report.mutation?.checkpointCount !== report.mutation?.beforeCount + 1 ||

--- a/apps/eidos-lite-desktop/src/main/diagnostics.test.ts
+++ b/apps/eidos-lite-desktop/src/main/diagnostics.test.ts
@@ -18,8 +18,8 @@ describe("Eidos Lite diagnostics", () => {
           graft: {
             available: true,
             backend: "sdk",
-            version: "0.3.0",
-            expectedVersion: "0.3.0",
+            version: "0.3.1",
+            expectedVersion: "0.3.1",
             initialized: true,
             clean: false,
           },

--- a/apps/eidos-lite-desktop/src/main/graft/graft-client.integration.test.ts
+++ b/apps/eidos-lite-desktop/src/main/graft/graft-client.integration.test.ts
@@ -209,7 +209,7 @@ describe("whole-Space real Graft integration", () => {
       expect(status).toMatchObject({
         available: true,
         backend: "sdk",
-        version: "0.3.0",
+        version: "0.3.1",
         initialized: true,
         clean: true,
         changedPaths: 0,

--- a/apps/eidos-lite-desktop/src/main/graft/graft-client.test.ts
+++ b/apps/eidos-lite-desktop/src/main/graft/graft-client.test.ts
@@ -87,7 +87,7 @@ describe("GraftClient", () => {
       close: vi.fn(async () => undefined),
       command: vi.fn(async (command) => {
         commands.push(command)
-        if (command === "sdkVersion") return "0.3.0"
+        if (command === "sdkVersion") return "0.3.1"
         if (command === "statusIncremental") {
           return {
             generation: 1,

--- a/apps/eidos-lite-desktop/src/main/graft/graft-client.ts
+++ b/apps/eidos-lite-desktop/src/main/graft/graft-client.ts
@@ -20,7 +20,7 @@ import type { GraftSdkTransport } from "./graft-sdk-transport"
 
 const SDK_DIFF_PAGE_SIZE = 100
 const SDK_PATH_BATCH_SIZE = 1_000
-export const GRAFT_SDK_VERSION = "0.3.0"
+export const GRAFT_SDK_VERSION = "0.3.1"
 
 export interface GraftClientOptions {
   sdkTransport: GraftSdkTransport

--- a/apps/eidos-lite-desktop/src/main/space/space-session.integration.test.ts
+++ b/apps/eidos-lite-desktop/src/main/space/space-session.integration.test.ts
@@ -28,13 +28,13 @@ describe("SpaceSession Graft-backed snapshots", () => {
     const graft = {
       backend: "sdk",
       syncRemoteOrigin: "https://sync-staging.eidos.space",
-      expectedVersion: () => "0.3.0",
+      expectedVersion: () => "0.3.1",
       close: async () => undefined,
       inspectSpace: async () => ({
         available: true,
         backend: "sdk",
-        version: "0.3.0",
-        expectedVersion: "0.3.0",
+        version: "0.3.1",
+        expectedVersion: "0.3.1",
         initialized: true,
         clean: true,
       }),
@@ -86,8 +86,8 @@ describe("SpaceSession Graft-backed snapshots", () => {
     const cleanStatus: GraftSpaceStatus = {
       available: true,
       backend: "sdk",
-      version: "0.3.0",
-      expectedVersion: "0.3.0",
+      version: "0.3.1",
+      expectedVersion: "0.3.1",
       initialized: true,
       clean: true,
     }
@@ -95,7 +95,7 @@ describe("SpaceSession Graft-backed snapshots", () => {
     const graft = {
       backend: "sdk",
       syncRemoteOrigin: "https://sync-staging.eidos.space",
-      expectedVersion: () => "0.3.0",
+      expectedVersion: () => "0.3.1",
       close: async () => undefined,
       inspectSpace: (_root: string, options: { signal?: AbortSignal } = {}) => {
         statusCalls += 1
@@ -295,8 +295,8 @@ describe("SpaceSession Graft-backed snapshots", () => {
     const cleanStatus: GraftSpaceStatus = {
       available: true,
       backend: "sdk",
-      version: "0.3.0",
-      expectedVersion: "0.3.0",
+      version: "0.3.1",
+      expectedVersion: "0.3.1",
       initialized: true,
       clean: true,
       currentHead: "a".repeat(64),
@@ -312,7 +312,7 @@ describe("SpaceSession Graft-backed snapshots", () => {
     const graft = {
       backend: "sdk",
       syncRemoteOrigin: "https://sync-staging.eidos.space",
-      expectedVersion: () => "0.3.0",
+      expectedVersion: () => "0.3.1",
       close: async () => undefined,
       inspectSpace: (_root: string, options: { signal?: AbortSignal } = {}) => {
         statusCalls += 1
@@ -489,7 +489,7 @@ describe("SpaceSession Graft-backed snapshots", () => {
     const graft = {
       backend: "sdk",
       syncRemoteOrigin: "https://sync-staging.eidos.space",
-      expectedVersion: () => "0.3.0",
+      expectedVersion: () => "0.3.1",
       open: async () => undefined,
       close: async () => undefined,
       inspectSpace: () => status.promise,
@@ -532,8 +532,8 @@ describe("SpaceSession Graft-backed snapshots", () => {
       status.resolve({
         available: true,
         backend: "sdk",
-        version: "0.3.0",
-        expectedVersion: "0.3.0",
+        version: "0.3.1",
+        expectedVersion: "0.3.1",
         initialized: false,
       })
       const final = await updated
@@ -566,7 +566,7 @@ describe("SpaceSession Graft-backed snapshots", () => {
     const graft = {
       backend: "sdk",
       syncRemoteOrigin: "https://sync-staging.eidos.space",
-      expectedVersion: () => "0.3.0",
+      expectedVersion: () => "0.3.1",
       open: async () => undefined,
       close: async () => undefined,
       inspectSpace: () => status.promise,
@@ -600,8 +600,8 @@ describe("SpaceSession Graft-backed snapshots", () => {
       status.resolve({
         available: true,
         backend: "sdk",
-        version: "0.3.0",
-        expectedVersion: "0.3.0",
+        version: "0.3.1",
+        expectedVersion: "0.3.1",
         initialized: true,
         error: "Tracked path is now a directory",
       })
@@ -636,7 +636,7 @@ describe("SpaceSession Graft-backed snapshots", () => {
     const graft = {
       backend: "sdk",
       syncRemoteOrigin: "https://sync-staging.eidos.space",
-      expectedVersion: () => "0.3.0",
+      expectedVersion: () => "0.3.1",
       close: vi.fn(async () => undefined),
       inspectSpace: (_root: string, options: { signal?: AbortSignal }) => {
         statusStarted()
@@ -683,14 +683,14 @@ describe("SpaceSession Graft-backed snapshots", () => {
     const graft = {
       backend: "sdk",
       syncRemoteOrigin: "https://sync-staging.eidos.space",
-      expectedVersion: () => "0.3.0",
+      expectedVersion: () => "0.3.1",
       open: async () => undefined,
       close: async () => undefined,
       inspectSpace: async () => ({
         available: true,
         backend: "sdk",
-        version: "0.3.0",
-        expectedVersion: "0.3.0",
+        version: "0.3.1",
+        expectedVersion: "0.3.1",
         initialized: true,
         clean: false,
       }),

--- a/apps/eidos-lite-desktop/src/main/space/working-text-diff.test.ts
+++ b/apps/eidos-lite-desktop/src/main/space/working-text-diff.test.ts
@@ -22,8 +22,8 @@ describe("working text diff", () => {
       inspectSpace: vi.fn(async () => ({
         available: true,
         backend: "sdk" as const,
-        version: "0.3.0",
-        expectedVersion: "0.3.0",
+        version: "0.3.1",
+        expectedVersion: "0.3.1",
         initialized: true,
         clean: false,
         currentHead: head,
@@ -89,8 +89,8 @@ describe("working text diff", () => {
       inspectSpace: vi.fn(async () => ({
         available: true,
         backend: "sdk" as const,
-        version: "0.3.0",
-        expectedVersion: "0.3.0",
+        version: "0.3.1",
+        expectedVersion: "0.3.1",
         initialized: true,
         clean: false,
         currentHead: head,

--- a/apps/eidos-lite-desktop/src/main/sync/push-publication-failure.test.ts
+++ b/apps/eidos-lite-desktop/src/main/sync/push-publication-failure.test.ts
@@ -53,8 +53,8 @@ describe("push publication failure", () => {
       inspectSpace: vi.fn(async () => ({
         available: true,
         backend: "sdk" as const,
-        version: "0.3.0",
-        expectedVersion: "0.3.0",
+        version: "0.3.1",
+        expectedVersion: "0.3.1",
         initialized: true,
         clean: true,
         currentHead: localHead,

--- a/apps/eidos-lite-desktop/src/main/sync/push-publication-process-crash.test.ts
+++ b/apps/eidos-lite-desktop/src/main/sync/push-publication-process-crash.test.ts
@@ -141,14 +141,14 @@ describe("push publication process crash recovery", () => {
         })
         const graft = {
           syncRemoteOrigin: origin,
-          expectedVersion: vi.fn(() => "0.3.0"),
+          expectedVersion: vi.fn(() => "0.3.1"),
           open: vi.fn(async () => undefined),
           close: vi.fn(async () => undefined),
           inspectSpace: vi.fn(async () => ({
             available: true,
             backend: "sdk" as const,
-            version: "0.3.0",
-            expectedVersion: "0.3.0",
+            version: "0.3.1",
+            expectedVersion: "0.3.1",
             initialized: true,
             clean: true,
             currentHead: localHead,

--- a/apps/eidos-lite-desktop/src/renderer/version-panel.test.ts
+++ b/apps/eidos-lite-desktop/src/renderer/version-panel.test.ts
@@ -76,7 +76,7 @@ const unversionedSpace: SpaceSnapshot = {
   graft: {
     available: true,
     backend: "sdk",
-    expectedVersion: "0.3.0",
+    expectedVersion: "0.3.1",
     initialized: false,
   },
   invalidatedSessionIds: [],

--- a/apps/graft-remote/README.md
+++ b/apps/graft-remote/README.md
@@ -18,7 +18,7 @@ GRAFT_REMOTE_TOKEN. CLI keys are independent of Desktop sessions and devices.
 
 Wire behavior comes exclusively from the official npm packages released from
 the `eidos-space/graft` repository at commit
-`795a76fee4804295d5c3487de5bcf4ed2b8e635a`:
+`1f90077a8d43ff767c4233e526a1fd0bccdde453`:
 
 - @eidos.space/graft-remote owns Remote v1 validation, status codes, range
   reads, conditional operations, pagination, and the Graft-Protocol: 1 header.
@@ -26,7 +26,7 @@ the `eidos-space/graft` repository at commit
 - @eidos.space/graft-remote-cloudflare owns the R2 and SQLite Durable Object
   backend.
 
-The service pins the three public Remote packages to `0.1.0`; no upstream
+The service pins the three public Remote packages to `0.2.0`; no upstream
 implementation is copied into the Eidos repository. Eidos-specific code does
 not duplicate or version-gate the protocol. A newer official Remote release
 becomes the tested baseline only after the service checks and current CLI

--- a/apps/graft-remote/package.json
+++ b/apps/graft-remote/package.json
@@ -15,9 +15,9 @@
     "types": "wrangler types worker-configuration.d.ts --include-runtime false"
   },
   "dependencies": {
-    "@eidos.space/graft-remote": "0.1.0",
-    "@eidos.space/graft-remote-cloudflare": "0.1.0",
-    "@eidos.space/graft-remote-hono": "0.1.0",
+    "@eidos.space/graft-remote": "0.2.0",
+    "@eidos.space/graft-remote-cloudflare": "0.2.0",
+    "@eidos.space/graft-remote-hono": "0.2.0",
     "hono": "4.12.31"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -428,8 +428,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/eidos-file-ui
       '@eidos.space/graft':
-        specifier: 0.3.0
-        version: 0.3.0
+        specifier: 0.3.1
+        version: 0.3.1
       '@glideapps/glide-data-grid':
         specifier: ^6.0.0
         version: 6.0.3(lodash@4.18.1)(marked@4.3.0)(react-dom@18.3.1(react@18.3.1))(react-responsive-carousel@3.2.23)(react@18.3.1)
@@ -507,14 +507,14 @@ importers:
   apps/graft-remote:
     dependencies:
       '@eidos.space/graft-remote':
-        specifier: 0.1.0
-        version: 0.1.0
+        specifier: 0.2.0
+        version: 0.2.0
       '@eidos.space/graft-remote-cloudflare':
-        specifier: 0.1.0
-        version: 0.1.0(@cloudflare/workers-types@5.20260727.1)
+        specifier: 0.2.0
+        version: 0.2.0(@cloudflare/workers-types@5.20260727.1)
       '@eidos.space/graft-remote-hono':
-        specifier: 0.1.0
-        version: 0.1.0(hono@4.12.31)
+        specifier: 0.2.0
+        version: 0.2.0(hono@4.12.31)
       hono:
         specifier: 4.12.31
         version: 4.12.31
@@ -3253,54 +3253,54 @@ packages:
   '@eidos.space/core@0.28.3':
     resolution: {integrity: sha512-C++s4lGnoCuUjPfCvZKLxp0flhM1LsQpic6aNUz3GwkX65VtILMG1pEIaRtzqGhNt3UULw8ac+/KTjrW8NGzRQ==}
 
-  '@eidos.space/graft-darwin-arm64@0.3.0':
-    resolution: {integrity: sha512-RUny4RtDXgMphmNMdvqeStpgb0KOq38mQRmwj5nQWiiVLehNiNsxs/O4Q6YRyPlZoV78h/Iu0urYyUqYC2mi7A==}
+  '@eidos.space/graft-darwin-arm64@0.3.1':
+    resolution: {integrity: sha512-iouW2cqBYv38XMHDDmNKLruCYs52dqyUZeHsPXchwAjd71LY/Lh5Bw06q/lvHke0fycYGbMpLeBw8+ZXirsrPA==}
     engines: {node: '>=20'}
     cpu: [arm64]
     os: [darwin]
 
-  '@eidos.space/graft-darwin-x64@0.3.0':
-    resolution: {integrity: sha512-OPW3HTIUpe9ErClXpK4u5MH9/SEJFo+DYpacMCMRTD8C3j+S9EYbvAK0i7O0VVGWAmifhIYBhzM2oidY9rto5Q==}
+  '@eidos.space/graft-darwin-x64@0.3.1':
+    resolution: {integrity: sha512-X94846NWqnNkYXXuQz6uw1Wn8UiYLqNpyr3+Sxq2AdiP9vdIP2myfPwRmhzOGLr6EJ9rqboh1CQOCxmpn28CoQ==}
     engines: {node: '>=20'}
     cpu: [x64]
     os: [darwin]
 
-  '@eidos.space/graft-linux-arm64-gnu@0.3.0':
-    resolution: {integrity: sha512-Lp2XwHSKCgOEj3GVIlGh8BG0x06Ml1v9tUl2Uo/mS3F6HnMlJJK+ha+Yz/ybqqkq8NNiZm8lNom9cIKFatVsqw==}
+  '@eidos.space/graft-linux-arm64-gnu@0.3.1':
+    resolution: {integrity: sha512-gWN8bbQl7/sl0qitl9fjv/oJOZYLHI4kOrwTsyWA7/qC3yrDiX3aDF5IBK8M0m5BaseLkNrzU6zOPuedfW3CIQ==}
     engines: {node: '>=20'}
     cpu: [arm64]
     os: [linux]
 
-  '@eidos.space/graft-linux-x64-gnu@0.3.0':
-    resolution: {integrity: sha512-v7UVdhSmd4VyIEx6Iph6HkVFC4ttRRFUnjdu9sxYM/UGdScqm2Tm4lGtLSdH5E/BwusRCYP7wC+iFWJS74pcsQ==}
+  '@eidos.space/graft-linux-x64-gnu@0.3.1':
+    resolution: {integrity: sha512-lxDznTOcPq8OUHmeCSbhJAgTRThH01kPwCQ6alQv1Nk19UsePIUTgaGb5slHqZNPxRXCcvPBNNSFz+uWLeF56Q==}
     engines: {node: '>=20'}
     cpu: [x64]
     os: [linux]
 
-  '@eidos.space/graft-remote-cloudflare@0.1.0':
-    resolution: {integrity: sha512-G6NlxSCD5OqYIQ5SZmNynW1F+B+A9oajQGY0R5N97M3ck7vyyMfRSNBlsWUwSOWF4jfZX0888s+twZveUZTmUA==}
+  '@eidos.space/graft-remote-cloudflare@0.2.0':
+    resolution: {integrity: sha512-70LNqBlTXLWFGv0mD0tVa6HY207yR/XQYHmunp3R5dvfKYPAyFX/RWMFhc/aFDhj3ombpX9VBj5P58uOwp2vCw==}
     engines: {node: '>=20'}
     peerDependencies:
       '@cloudflare/workers-types': ^5.20260722.1
 
-  '@eidos.space/graft-remote-hono@0.1.0':
-    resolution: {integrity: sha512-KtqvakfkYUedxKUp2SohUGxqMNvlgWBayr2KlxeE7esQPP3dc5XNMjUNEfhvOEbFHRIZCpTfLITNXWbkt9Lp6A==}
+  '@eidos.space/graft-remote-hono@0.2.0':
+    resolution: {integrity: sha512-PaXzBAnRvxoG6wNZzQymo6xwXswkzbUWsE1768sUKPmCNyvc02vvKKlZwX96wxrtTPyEkbsj0m1mbEOqwDESKg==}
     engines: {node: '>=20'}
     peerDependencies:
       hono: ^4.12.31
 
-  '@eidos.space/graft-remote@0.1.0':
-    resolution: {integrity: sha512-Js84WFgutZ0h9vu1YAZYqD+F0N2H1JbJgV6pmciiQ1tBzaHYeIy3okKmxhznqG1mTPr89XHeVu1sFKK4nmob1Q==}
+  '@eidos.space/graft-remote@0.2.0':
+    resolution: {integrity: sha512-O1ynq3Ra52jMbgoOVd0dqSs09f9/3I8twqbbKiFBVkQX/njOA6ud+9V/5XHf0CIIfB6Eo6arJz28gDtIWNU1Bw==}
     engines: {node: '>=20'}
 
-  '@eidos.space/graft-win32-x64-msvc@0.3.0':
-    resolution: {integrity: sha512-5tgO5Ewtac/C1Q6E/rPrTfsqqmCYwFHaJO7Imo8wvCCMIcCNysU2CXjezBjeYaA6UHk+jfj4NpSyd4mvdBewmQ==}
+  '@eidos.space/graft-win32-x64-msvc@0.3.1':
+    resolution: {integrity: sha512-Jt6Y4XH8Jc6wocfFIgJvO234XdQ5hWfBUlmTEaBojHLdSdBOykbbldnlpC7KEd54ymJ3Sbu/9lKh/mTz6xgBZQ==}
     engines: {node: '>=20'}
     cpu: [x64]
     os: [win32]
 
-  '@eidos.space/graft@0.3.0':
-    resolution: {integrity: sha512-lMSCX4Zt1od4fNb74aFcARTbZ0pBtCudIPL5gl6m3Hp1AA+gXzBooOIBdc5lOtpMZZVuZ4dOMiZprHENSeGjuw==}
+  '@eidos.space/graft@0.3.1':
+    resolution: {integrity: sha512-gUU59DPTVeplr931V4WsATAbuZ4vWt1rGtmiR8yU/VR3kDPDFymQ9B9kBfFoT33rkkx/Z19wtLM/f7bMe4/BZw==}
     engines: {node: '>=20'}
 
   '@electron/asar@3.4.1':
@@ -14863,40 +14863,40 @@ snapshots:
     transitivePeerDependencies:
       - zod
 
-  '@eidos.space/graft-darwin-arm64@0.3.0':
+  '@eidos.space/graft-darwin-arm64@0.3.1':
     optional: true
 
-  '@eidos.space/graft-darwin-x64@0.3.0':
+  '@eidos.space/graft-darwin-x64@0.3.1':
     optional: true
 
-  '@eidos.space/graft-linux-arm64-gnu@0.3.0':
+  '@eidos.space/graft-linux-arm64-gnu@0.3.1':
     optional: true
 
-  '@eidos.space/graft-linux-x64-gnu@0.3.0':
+  '@eidos.space/graft-linux-x64-gnu@0.3.1':
     optional: true
 
-  '@eidos.space/graft-remote-cloudflare@0.1.0(@cloudflare/workers-types@5.20260727.1)':
+  '@eidos.space/graft-remote-cloudflare@0.2.0(@cloudflare/workers-types@5.20260727.1)':
     dependencies:
       '@cloudflare/workers-types': 5.20260727.1
-      '@eidos.space/graft-remote': 0.1.0
+      '@eidos.space/graft-remote': 0.2.0
 
-  '@eidos.space/graft-remote-hono@0.1.0(hono@4.12.31)':
+  '@eidos.space/graft-remote-hono@0.2.0(hono@4.12.31)':
     dependencies:
-      '@eidos.space/graft-remote': 0.1.0
+      '@eidos.space/graft-remote': 0.2.0
       hono: 4.12.31
 
-  '@eidos.space/graft-remote@0.1.0': {}
+  '@eidos.space/graft-remote@0.2.0': {}
 
-  '@eidos.space/graft-win32-x64-msvc@0.3.0':
+  '@eidos.space/graft-win32-x64-msvc@0.3.1':
     optional: true
 
-  '@eidos.space/graft@0.3.0':
+  '@eidos.space/graft@0.3.1':
     optionalDependencies:
-      '@eidos.space/graft-darwin-arm64': 0.3.0
-      '@eidos.space/graft-darwin-x64': 0.3.0
-      '@eidos.space/graft-linux-arm64-gnu': 0.3.0
-      '@eidos.space/graft-linux-x64-gnu': 0.3.0
-      '@eidos.space/graft-win32-x64-msvc': 0.3.0
+      '@eidos.space/graft-darwin-arm64': 0.3.1
+      '@eidos.space/graft-darwin-x64': 0.3.1
+      '@eidos.space/graft-linux-arm64-gnu': 0.3.1
+      '@eidos.space/graft-linux-x64-gnu': 0.3.1
+      '@eidos.space/graft-win32-x64-msvc': 0.3.1
 
   '@electron/asar@3.4.1':
     dependencies:


### PR DESCRIPTION
## Summary
- pin the hosted Remote worker to the official 0.2.0 packages
- pin Eidos Lite to the official Graft SDK 0.3.1 package and update its runtime version contract
- refresh the lockfile and release documentation

## Verification
- Remote service check passed
- Remote service tests: 16 passed
- Wrangler staging dry-run passed
- Eidos Lite typecheck passed
- Graft real integration tests: 12 passed
- Version-related regression tests: 30 passed
- staging deployment health and discovery endpoints returned HTTP 200

## Staging
Deployed Worker version: d2f3b76d-0773-431d-9f99-73237566f9e6