### PR TITLE
fix(desktop): avoid false port-in-use from parallel IPv4/IPv6 probe

### DIFF
--- a/apps/desktop/electron/modules/api-server/port-checker.test.ts
+++ b/apps/desktop/electron/modules/api-server/port-checker.test.ts
@@ -1,0 +1,69 @@
+// @vitest-environment node
+
+import net from "node:net"
+
+import { describe, expect, it, vi } from "vitest"
+
+vi.mock("electron", () => ({ dialog: { showMessageBox: vi.fn() } }))
+
+import { isPortInUse } from "./port-checker"
+
+function listen(port: number, host: string): Promise<net.Server> {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer()
+    server.once("error", reject)
+    server.listen(port, host, () => resolve(server))
+  })
+}
+
+function close(server: net.Server): Promise<void> {
+  return new Promise((resolve) => server.close(() => resolve()))
+}
+
+async function getFreePort(): Promise<number> {
+  const server = await listen(0, "127.0.0.1")
+  const port = (server.address() as net.AddressInfo).port
+  await close(server)
+  return port
+}
+
+describe("isPortInUse", () => {
+  it("reports a free port as free", async () => {
+    const port = await getFreePort()
+    expect(await isPortInUse(port)).toBe(false)
+  })
+
+  it("reports an occupied port as occupied", async () => {
+    const port = await getFreePort()
+    const server = await listen(port, "0.0.0.0")
+    try {
+      expect(await isPortInUse(port)).toBe(true)
+    } finally {
+      await close(server)
+    }
+  })
+
+  it("reports an IPv6-only occupied port as occupied", async (ctx) => {
+    const port = await getFreePort()
+    let server: net.Server
+    try {
+      server = await listen(port, "::1")
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code
+      // Hosts without IPv6 (some containers) cannot bind ::1 at all
+      if (
+        code === "EADDRNOTAVAIL" ||
+        code === "EAFNOSUPPORT" ||
+        code === "EPROTONOSUPPORT"
+      ) {
+        ctx.skip(`IPv6 loopback unavailable (${code})`)
+      }
+      throw err
+    }
+    try {
+      expect(await isPortInUse(port)).toBe(true)
+    } finally {
+      await close(server)
+    }
+  })
+})

--- a/apps/desktop/electron/modules/api-server/port-checker.ts
+++ b/apps/desktop/electron/modules/api-server/port-checker.ts
@@ -48,12 +48,15 @@ function checkPortOnHost(port: number, host: string): Promise<boolean> {
  * Checks on all interfaces (IPv4 and IPv6) to detect any binding
  */
 export async function isPortInUse(port: number): Promise<boolean> {
-  // Check both IPv4 and IPv6 to ensure comprehensive detection
-  const [ipv4InUse, ipv6InUse] = await Promise.all([
-    checkPortOnHost(port, "0.0.0.0"),
-    checkPortOnHost(port, "::").catch(() => false), // IPv6 might not be available
-  ])
-  return ipv4InUse || ipv6InUse
+  // Probe sequentially, not in parallel. On Linux a bind to `::` is dual-stack
+  // (it also covers IPv4), so two simultaneous probes on 0.0.0.0 and :: collide
+  // with each other: whichever bind lands second fails with EADDRINUSE against
+  // the first probe's own socket, falsely reporting a free port as occupied on
+  // any dual-stack machine.
+  if (await checkPortOnHost(port, "0.0.0.0")) {
+    return true
+  }
+  return checkPortOnHost(port, "::").catch(() => false) // IPv6 might not be available
 }
 
 /**


### PR DESCRIPTION
## Context

Base: `dev` @ 0380664. On dual-stack Linux, Eidos refuses to start: the startup port check reports port 13127 as "in use" although nothing listens on it, and the retry dialog can never succeed (verified with `ss`/`lsof`: port genuinely free). No existing issue tracked this; root cause traced in the bundled 0.32.2 build and reproduced against `dev`.

## Changes

- `isPortInUse()` now probes `0.0.0.0` and `::` sequentially instead of in parallel. On Linux a bind to `::` is dual-stack (it also covers IPv4), so two simultaneous probes collide with each other: whichever bind lands second fails with `EADDRINUSE` against the first probe's own socket. Reproduced with the old code: the check false-positives 20/20 runs on this machine, while each probe alone reports the port free. With the fix: 0/20 false positives, and a genuinely occupied port is still detected.

## Verification

- New regression test `apps/desktop/electron/modules/api-server/port-checker.test.ts`: asserts a free port reports free and that occupied ports report occupied (IPv4 wildcard and IPv6-only `::1` occupants; the v6 case skips on hosts without IPv6).
- Against the unfixed code the test fails exactly on "reports a free port as free" (1 failed, 2 passed); against the fixed code 3/3 pass (`pnpm exec vitest run apps/desktop/electron/modules/api-server/port-checker.test.ts`).
- The same code path was validated in the shipped 0.32.2 desktop bundle via an equivalent in-place patch: the app starts, binds `*:13127`, and serves sandbox requests.

## Deferred

- The kill-process dialog flow (`showPortInUseDialog`) is untouched; it now only triggers on genuine conflicts.

## Files (2)

- apps/desktop/electron/modules/api-server/port-checker.test.ts [ADDED] (+69 -0)
- apps/desktop/electron/modules/api-server/port-checker.ts [MODIFIED] (+9 -6)
