### PR TITLE
fix(lite): keep cross-platform clones clean

### DIFF
--- a/.github/workflows/eidos-lite-desktop-gates.yml
+++ b/.github/workflows/eidos-lite-desktop-gates.yml
@@ -21,8 +21,41 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  macos-clone-fixture:
+    name: Prepare macOS clone fixture
+    runs-on: macos-15
+    timeout-minutes: 15
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".node-version"
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Prepare committed macOS Graft Space
+        run: >-
+          node apps/eidos-lite-desktop/scripts/prepare-cross-platform-clone-fixture.mjs
+          "${{ runner.temp }}/eidos-lite-clone-fixture"
+
+      - name: Upload committed macOS Graft Space
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-graft-space
+          path: ${{ runner.temp }}/eidos-lite-clone-fixture
+          include-hidden-files: true
+          if-no-files-found: error
+
   windows-clone-validation:
     name: Windows clone validation
+    needs: macos-clone-fixture
     runs-on: windows-latest
     timeout-minutes: 15
     steps:
@@ -40,10 +73,18 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Download committed macOS Graft Space
+        uses: actions/download-artifact@v4
+        with:
+          name: macos-graft-space
+          path: ${{ runner.temp }}/eidos-lite-clone-fixture
+
       - name: Typecheck
         run: pnpm --filter "@eidos.space/eidos-lite-desktop" typecheck
 
       - name: Verify clone validation is read-only
+        env:
+          EIDOS_LITE_CROSS_PLATFORM_FIXTURE: ${{ runner.temp }}/eidos-lite-clone-fixture
         run: >-
           pnpm --filter "@eidos.space/eidos-lite-desktop" exec node
           ../../scripts/run-electron-node.mjs
@@ -51,6 +92,7 @@ jobs:
           --config vitest.config.ts
           src/main/runtime/runtime-pool.test.ts
           src/runtime/eidos-file-runtime.test.ts
+          src/runtime/cross-platform-clone.test.ts
 
   source-and-real-graft:
     name: Source and real Graft SDK

--- a/apps/eidos-lite-desktop/README.md
+++ b/apps/eidos-lite-desktop/README.md
@@ -7,7 +7,7 @@
 > architecture and verification contract.
 
 Eidos Lite 0.1.12 is the current release. Local Spaces, editing, and version
-history require no account. It uses Graft SDK 0.3.21 for durable merge state,
+history require no account. It uses Graft SDK 0.3.22 for durable merge state,
 policy-governed SQLite resolution, sparse large-database merge execution,
 cooperative cancellation, and safe retry/reopen behavior.
 Eidos Sync remains an invite-only private preview: users
@@ -125,7 +125,7 @@ credentials. The titlebar and Sync panel expose queued, running, retry-wait,
 and paused states. Local-only Spaces still neither log in nor create a Sync
 queue.
 
-Graft runs through the published `@eidos.space/graft@0.3.21` Node-API SDK.
+Graft runs through the published `@eidos.space/graft@0.3.22` Node-API SDK.
 Opening a Space does not open or classify its repository. The root Explorer and
 local Eidos File runtime become usable first; the first background or explicit
 version operation lazily starts one Electron utility process and retains one

--- a/apps/eidos-lite-desktop/RELEASE_NOTES.md
+++ b/apps/eidos-lite-desktop/RELEASE_NOTES.md
@@ -1,16 +1,11 @@
 ## What's new
 
-### Publish reliably from macOS
+### Keep Windows clones clean
 
-The macOS installer now includes the dedicated Eidos Publish engine used by
-Eidos Lite. Publishing and collecting no longer fail with an unavailable-engine
-message after installation, and packaged release checks now execute the bundled
-engine before an installer can be published.
-
-### Keep cloned Spaces unchanged
-
-Validation after cloning is now read-only. Opening a Space cloned from another
-device no longer rewrites valid Eidos Files or makes every file appear modified
-before the user changes anything.
+Eidos Lite now treats SQLite page-header values rewritten by a Windows backup
+snapshot as non-user changes. A Space checkpointed on macOS stays clean after
+it is cloned to Windows, so Sync can continue without an empty checkpoint.
+Derived Graft status caches rebuild automatically; files and history are
+unchanged.
 
 No migration is required.

--- a/apps/eidos-lite-desktop/docs/ARCHITECTURE.md
+++ b/apps/eidos-lite-desktop/docs/ARCHITECTURE.md
@@ -63,7 +63,7 @@ flowchart LR
   F1 -->|"guarded node:sqlite handle"| E1["a.eidos"]
   F2 -->|"guarded node:sqlite handle"| E2["nested/b.eidos"]
   M -->|"typed private IPC; one process per Space"| G["Graft utility process"]
-  G -->|"one retained RepositorySession"| N["Official Node-API SDK 0.3.21"]
+  G -->|"one retained RepositorySession"| N["Official Node-API SDK 0.3.22"]
   N --> S["whole ordinary folder Space"]
   N -. "explicit in-memory credential; Sync/Clone only" .-> H["Selected official Hosted Remote"]
 ```
@@ -359,7 +359,7 @@ SDK session transport at construction. Status, diff, history, checkpoint,
 restore, push, and clone never create a CLI subprocess; Lite has no backend
 switch, executable lookup, or CLI credential environment path.
 
-The SDK adapter pins published `@eidos.space/graft@0.3.21`,
+The SDK adapter pins published `@eidos.space/graft@0.3.22`,
 lazily opens one session on the first background or explicit repository read,
 and closes it when the window closes. It asks the published
 `operationMaterializesWorktree()` contract before restore. Remote credentials
@@ -621,7 +621,7 @@ conflict is never by itself proof that an Eidos candidate is safe.
    Abort restores the pre-merge Local head and retains Hosted history.
 
 The merge surface is compiled against a type-only snapshot kept aligned with
-the published Graft 0.3.21 declaration. `EIDOS_LITE_GRAFT_SDK_PATH` may select
+the published Graft 0.3.22 declaration. `EIDOS_LITE_GRAFT_SDK_PATH` may select
 a compatible local package in source development and tests; production always
 resolves the pinned SDK and fails closed with a typed unavailable result if its
 runtime contract is incomplete.

--- a/apps/eidos-lite-desktop/docs/DELIVERY-STATUS.md
+++ b/apps/eidos-lite-desktop/docs/DELIVERY-STATUS.md
@@ -22,7 +22,7 @@ in an in-memory LRU. The product deliberately does not expose multi-file tabs.
 | Eidos File editing      | Ready                     | Canonical `eidos-file-ui` Grid/View/Query/Fields/Sheet UI, real SQLite transactions, one active editor and a three-runtime LRU                                    |
 | Local versioning        | Ready                     | Whole-Space status, Changes, row-aware diff, History, checkpoint, forward-only restore and stable-change automatic checkpoints through the resident Graft SDK     |
 | Sync control plane      | Staging-ready             | Independent PKCE/device/grant flow, preflight upload scope, official Hosted Remote provisioning, background queue, typed failures and Local-safe recovery         |
-| Whole-Space Sync        | Private-preview ready     | Real staging push/clone/pull and divergence acceptance is recorded in [Operations](./OPERATIONS.md); reviewed merge uses the published Graft SDK 0.3.21           |
+| Whole-Space Sync        | Private-preview ready     | Real staging push/clone/pull and divergence acceptance is recorded in [Operations](./OPERATIONS.md); reviewed merge uses the published Graft SDK 0.3.22           |
 | Recovery                | Release verified          | Durable merge reopen/abort, operation journals, close/validate/reopen materialization, two-copy recovery, external invalidation, and utility crash reopen         |
 | Diagnostics             | Internal-ready            | Main-owned allowlisted Copy diagnostics excludes credentials, URLs, paths, Space/repository identity and user content                                             |
 | Distribution operations | Runbook-ready             | Clean install, upgrade, binary rollback, association, support and uninstall procedure in [Release runbook](./RELEASE-RUNBOOK.md)                                  |
@@ -39,7 +39,7 @@ The final local audit passed:
   reopen -> stale CAS rejection -> remaining table choices -> path unresolve ->
   full validation -> two-parent continue -> push/fetch equality. The same test
   covers partial resolution, reopen, abort, cancellation, idempotent status,
-  and a transient filesystem Remote failure. Graft SDK 0.3.21 is pinned in the
+  and a transient filesystem Remote failure. Graft SDK 0.3.22 is pinned in the
   lockfile, and the real merge flow passed against the published registry
   package.
 
@@ -57,7 +57,7 @@ The final local audit passed:
   passes and is not mislabeled as an automatic merged result.
 - Published Graft SDK integration: 14 passed, covering whole-Space push/clone,
   diff/restore, retained session lifecycle, memory-only HTTP credentials and
-  divergence analysis. The published Graft 0.3.21 merge E2E also passed both
+  divergence analysis. The published Graft 0.3.22 merge E2E also passed both
   availability and full dual-client cases. The semantic-provider integration
   additionally proves automatic Eidos system-metadata acceptance, persisted
   domain conflicts, exact state tokens, and Runtime validation.

--- a/apps/eidos-lite-desktop/docs/MERGE-SCHEMA-COMPATIBILITY.md
+++ b/apps/eidos-lite-desktop/docs/MERGE-SCHEMA-COMPATIBILITY.md
@@ -1,7 +1,7 @@
 # Eidos Lite merge schema compatibility matrix
 
 Status: living product and verification contract  
-Applies to: Eidos Lite reviewed merge with Graft SDK 0.3.21
+Applies to: Eidos Lite reviewed merge with Graft SDK 0.3.22
 Last reviewed: 2026-08-16
 
 ## Purpose and ownership
@@ -368,7 +368,7 @@ product contract and therefore remains a release blocker for that scenario.
 
 ### `GRAFT-SCHEMA-GAP-001`: validation-required candidates lack a standalone materialization operation
 
-Graft 0.3.21 automatically materializes compatible column/table/index/view/
+Graft 0.3.22 automatically materializes compatible column/table/index/view/
 trigger unions in a directory repository. It can also install a validated
 final SQLite candidate directly when merge analysis has accepted that result.
 For a more complex candidate that still requires application validation, such
@@ -416,7 +416,7 @@ before Lite can claim Field-index merge coverage.
 
 ### Closed: `GRAFT-SCHEMA-GAP-003` malformed tracked SQLite diagnostics
 
-Graft 0.3.21 returns structured `path_diagnostics` for skipped, corrupt, and
+Graft 0.3.22 returns structured `path_diagnostics` for skipped, corrupt, and
 analysis-failed tracked SQLite paths, including `protected_by_index`. Lite
 projects the diagnostics, blocks merge planning, and preserves the worktree
 file while directing the user to repair or recovery. This closes the prior
@@ -425,7 +425,7 @@ published or silently replaced.
 
 ### Closed: `GRAFT-SCHEMA-GAP-002` table/view same-name selection
 
-Graft 0.3.21 reports `schema_same_name_conflict` and safely completes either the
+Graft 0.3.22 reports `schema_same_name_conflict` and safely completes either the
 Local table or Hosted view complete-file choice. The real directory-repository
 matrix verifies both final `sqlite_schema` object types and no longer observes
 the former `Invalid page number` failure.

--- a/apps/eidos-lite-desktop/docs/OPERATIONS.md
+++ b/apps/eidos-lite-desktop/docs/OPERATIONS.md
@@ -238,7 +238,7 @@ sequence.
 
 ## Stable Graft supply chain
 
-The runtime pins published `@eidos.space/graft@0.3.21`; npm selects one of its
+The runtime pins published `@eidos.space/graft@0.3.22`; npm selects one of its
 five exact-version optional native packages for the current platform. Packaging
 keeps the JavaScript wrapper in ASAR and unpacks only the selected native
 package; `graft-worker.js` loads it directly in an Electron
@@ -771,7 +771,7 @@ EIDOS_LITE_RUN_GRAFT_MERGE=1 \
   src/main/graft/graft-merge-schema.local.integration.test.ts
 ```
 
-Graft 0.3.21 protects `applyMerge` with the reviewed HEAD, plan token, and clean
+Graft 0.3.22 protects `applyMerge` with the reviewed HEAD, plan token, and clean
 worktree guards, so Lite does not precede it with another full-Space status
 scan. A validation-required SQLite candidate may still be reported as
 `automatic_merge_available` while the worktree remains Local. Do not stage that

--- a/apps/eidos-lite-desktop/package.json
+++ b/apps/eidos-lite-desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eidos.space/eidos-lite-desktop",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "description": "Independent local-first desktop client for Eidos File Spaces",
   "author": "mayneyao",
@@ -33,7 +33,7 @@
   "dependencies": {
     "@eidos.space/eidos-file": "workspace:*",
     "@eidos.space/eidos-file-ui": "workspace:*",
-    "@eidos.space/graft": "0.3.21",
+    "@eidos.space/graft": "0.3.22",
     "@glideapps/glide-data-grid": "^6.0.0",
     "@pierre/diffs": "1.3.2",
     "@pierre/trees": "1.0.0-beta.5",

--- a/apps/eidos-lite-desktop/scripts/packaged-smoke.mjs
+++ b/apps/eidos-lite-desktop/scripts/packaged-smoke.mjs
@@ -301,7 +301,7 @@ try {
     ) ||
     !report.graft?.available ||
     report.graft?.backend !== "sdk" ||
-    report.graft?.version !== "0.3.21" ||
+    report.graft?.version !== "0.3.22" ||
     report.mutation?.afterInsertCount !== report.mutation?.beforeCount + 1 ||
     report.mutation?.afterDeleteCount !== report.mutation?.beforeCount ||
     report.mutation?.checkpointCount !== report.mutation?.beforeCount + 1 ||

--- a/apps/eidos-lite-desktop/scripts/prepare-cross-platform-clone-fixture.mjs
+++ b/apps/eidos-lite-desktop/scripts/prepare-cross-platform-clone-fixture.mjs
@@ -1,0 +1,35 @@
+import { cp, mkdir, rm } from "node:fs/promises"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+import { RepositorySession } from "@eidos.space/graft"
+
+const appRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
+const repositoryRoot = path.resolve(appRoot, "../..")
+const targetRoot = path.resolve(process.argv[2] ?? "")
+
+if (!process.argv[2]) {
+  throw new Error("Expected the fixture output directory as the first argument")
+}
+
+await rm(targetRoot, { recursive: true, force: true })
+await mkdir(targetRoot, { recursive: true })
+await cp(
+  path.join(
+    repositoryRoot,
+    "apps/eidos-file-web/fixtures/project-tracker.eidos"
+  ),
+  path.join(targetRoot, "project-tracker.eidos")
+)
+
+const repository = await RepositorySession.open(targetRoot)
+try {
+  await repository.init()
+  await repository.addAll()
+  await repository.commit("Cross-platform clone fixture")
+  const status = await repository.status()
+  if (status.dirty || status.paths.length > 0) {
+    throw new Error(`Fixture is not clean: ${JSON.stringify(status)}`)
+  }
+} finally {
+  await repository.close()
+}

--- a/apps/eidos-lite-desktop/src/main/graft/graft-client.test.ts
+++ b/apps/eidos-lite-desktop/src/main/graft/graft-client.test.ts
@@ -758,7 +758,7 @@ describe("GraftClient", () => {
       command: vi.fn(async (command) => {
         commands.push(command)
         if (command === "sdkVersion") {
-          return "0.3.21"
+          return "0.3.22"
         }
         if (command === "statusIncremental") {
           return {

--- a/apps/eidos-lite-desktop/src/main/graft/graft-client.ts
+++ b/apps/eidos-lite-desktop/src/main/graft/graft-client.ts
@@ -43,8 +43,8 @@ import type { GraftSdkTransport } from "./graft-sdk-transport"
 
 const SDK_DIFF_PAGE_SIZE = 100
 const SDK_PATH_BATCH_SIZE = 1_000
-export const GRAFT_SDK_VERSION = "0.3.21"
-export const GRAFT_LOCAL_MERGE_SDK_VERSION = "0.3.21"
+export const GRAFT_SDK_VERSION = "0.3.22"
+export const GRAFT_LOCAL_MERGE_SDK_VERSION = "0.3.22"
 
 export interface GraftClientOptions {
   sdkTransport: GraftSdkTransport

--- a/apps/eidos-lite-desktop/src/main/space/space-session.integration.test.ts
+++ b/apps/eidos-lite-desktop/src/main/space/space-session.integration.test.ts
@@ -1166,13 +1166,13 @@ describe("SpaceSession Graft-backed snapshots", () => {
     const graft = {
       backend: "sdk",
       syncRemoteOrigin: "https://sync-staging.eidos.space",
-      expectedVersion: () => "0.3.21",
+      expectedVersion: () => "0.3.22",
       close: async () => undefined,
       inspectSpace: async (): Promise<GraftSpaceStatus> => ({
         available: true,
         backend: "sdk",
-        version: "0.3.21",
-        expectedVersion: "0.3.21",
+        version: "0.3.22",
+        expectedVersion: "0.3.22",
         initialized: false,
       }),
       inspectIgnores: async (_root: string, relativePaths: string[]) =>
@@ -2113,13 +2113,13 @@ describe("SpaceSession Graft-backed snapshots", () => {
     const graft = {
       backend: "sdk",
       syncRemoteOrigin: remoteOrigin,
-      expectedVersion: () => "0.3.21",
+      expectedVersion: () => "0.3.22",
       close: vi.fn(async () => undefined),
       inspectSpace: vi.fn(async () => ({
         available: true,
         backend: "sdk" as const,
-        version: "0.3.21",
-        expectedVersion: "0.3.21",
+        version: "0.3.22",
+        expectedVersion: "0.3.22",
         initialized: true,
         clean: true,
         ...relation(),
@@ -2244,13 +2244,13 @@ describe("SpaceSession Graft-backed snapshots", () => {
     const graft = {
       backend: "sdk",
       syncRemoteOrigin: remoteOrigin,
-      expectedVersion: () => "0.3.21",
+      expectedVersion: () => "0.3.22",
       close: vi.fn(async () => undefined),
       inspectSpace: vi.fn(async () => ({
         available: true,
         backend: "sdk" as const,
-        version: "0.3.21",
-        expectedVersion: "0.3.21",
+        version: "0.3.22",
+        expectedVersion: "0.3.22",
         initialized: true,
         clean: true,
         currentHead: localHead,
@@ -2604,7 +2604,7 @@ describe("SpaceSession Graft-backed snapshots", () => {
     const graft = {
       backend: "sdk",
       syncRemoteOrigin: "https://sync-staging.eidos.space",
-      expectedVersion: () => "0.3.21",
+      expectedVersion: () => "0.3.22",
       close: vi.fn(async () => undefined),
       operationMaterializesWorktree: vi.fn(async (operation: string) => {
         calls.push(`contract:${operation}`)
@@ -2661,8 +2661,8 @@ describe("SpaceSession Graft-backed snapshots", () => {
       inspectSpace: vi.fn(async () => ({
         available: true,
         backend: "sdk" as const,
-        version: "0.3.21",
-        expectedVersion: "0.3.21",
+        version: "0.3.22",
+        expectedVersion: "0.3.22",
         initialized: true,
         clean: true,
         currentHead: localHead,

--- a/apps/eidos-lite-desktop/src/runtime/cross-platform-clone.test.ts
+++ b/apps/eidos-lite-desktop/src/runtime/cross-platform-clone.test.ts
@@ -1,0 +1,99 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import path from "node:path"
+import { RepositorySession, type StatusResult } from "@eidos.space/graft"
+
+import { openEidosLiteFileRuntime } from "./eidos-file-runtime"
+
+const fixtureRoot = process.env.EIDOS_LITE_CROSS_PLATFORM_FIXTURE
+const describeCrossPlatform = fixtureRoot ? describe : describe.skip
+
+function differingByteOffsets(left: Buffer, right: Buffer): number[] {
+  const offsets: number[] = []
+  const sharedBytes = Math.min(left.length, right.length)
+  for (let offset = 0; offset < sharedBytes; offset += 1) {
+    if (left[offset] !== right[offset]) offsets.push(offset)
+    if (offsets.length >= 256) break
+  }
+  if (left.length !== right.length && offsets.length < 256) {
+    offsets.push(sharedBytes)
+  }
+  return offsets
+}
+
+async function diagnoseDirtySqlite(
+  repository: RepositorySession,
+  root: string,
+  status: StatusResult
+): Promise<void> {
+  if (!status.dirty) return
+
+  const relativePath = "project-tracker.eidos"
+  const diagnosticRoot = await mkdtemp(
+    path.join(tmpdir(), "eidos-lite-cross-platform-diagnostic-")
+  )
+  const capturedPath = path.join(diagnosticRoot, relativePath)
+  try {
+    const summary = await repository.diffSqlitePaths({
+      paths: [relativePath],
+      mode: "summary",
+    })
+    const capture = await repository.captureSqliteSnapshot({
+      path: relativePath,
+      output: capturedPath,
+    })
+    const [worktreeBytes, capturedBytes] = await Promise.all([
+      readFile(path.join(root, relativePath)),
+      readFile(capturedPath),
+    ])
+    const offsets = differingByteOffsets(worktreeBytes, capturedBytes)
+    console.error(
+      JSON.stringify(
+        {
+          status,
+          summary,
+          capture,
+          worktreeBytes: worktreeBytes.length,
+          capturedBytes: capturedBytes.length,
+          firstDifferingByteOffsets: offsets,
+          firstDifferingPages: [
+            ...new Set(offsets.map((offset) => Math.floor(offset / 4096) + 1)),
+          ],
+        },
+        null,
+        2
+      )
+    )
+  } finally {
+    await rm(diagnosticRoot, { recursive: true, force: true })
+  }
+}
+
+describeCrossPlatform("cross-platform Graft clone", () => {
+  it("keeps a macOS-created Eidos File clean when opened on Windows", async () => {
+    const root = path.resolve(fixtureRoot!)
+    const filePath = path.join(root, "project-tracker.eidos")
+    const repository = await RepositorySession.open(root)
+    try {
+      const before = await repository.status()
+      await diagnoseDirtySqlite(repository, root, before)
+      expect(before).toMatchObject({ dirty: false, paths: [] })
+
+      let opened = await openEidosLiteFileRuntime(filePath, { readOnly: true })
+      await opened.close()
+      expect(await repository.status()).toMatchObject({
+        dirty: false,
+        paths: [],
+      })
+
+      opened = await openEidosLiteFileRuntime(filePath)
+      await opened.close()
+      expect(await repository.status()).toMatchObject({
+        dirty: false,
+        paths: [],
+      })
+    } finally {
+      await repository.close()
+    }
+  }, 120_000)
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -239,8 +239,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/eidos-file-ui
       '@eidos.space/graft':
-        specifier: 0.3.21
-        version: 0.3.21
+        specifier: 0.3.22
+        version: 0.3.22
       '@glideapps/glide-data-grid':
         specifier: ^6.0.0
         version: 6.0.3(lodash@4.18.1)(marked@4.3.0)(react-dom@18.3.1(react@18.3.1))(react-responsive-carousel@3.2.23)(react@18.3.1)
@@ -1640,26 +1640,26 @@ packages:
     peerDependencies:
       react: '>=16.8.0'
 
-  '@eidos.space/graft-darwin-arm64@0.3.21':
-    resolution: {integrity: sha512-jVCNQYEJOgKf/koftlLd2s0DI26lScpm6wlmU3BqvZtQugQNyDBFWmEbgckb4I0fPsSzL37IWZ4q/670EjW4mQ==}
+  '@eidos.space/graft-darwin-arm64@0.3.22':
+    resolution: {integrity: sha512-zt8N2/sENKkU6i7wVP4I58ilavGFkByywz6Ch1wGDJ7KtnffKJ3eAa3vg4WHzabJ7vA19Qc/NP1k27ZTo3jYXg==}
     engines: {node: '>=20'}
     cpu: [arm64]
     os: [darwin]
 
-  '@eidos.space/graft-darwin-x64@0.3.21':
-    resolution: {integrity: sha512-yMGWhImBLWhxdDJ7zQF9oir/nYZcWp6NO3Mz4xv7laTE2ah2gKkVWLcOWEQleNWkaVWqMSQtmUfTMZqCer0DWA==}
+  '@eidos.space/graft-darwin-x64@0.3.22':
+    resolution: {integrity: sha512-JAj78If8qFpcK8iDUe1WCqoKJZXACLEAlYwf4CjeGYIjE6KJT819z4Vry7qnDKZqa9X+D5fv2CDSYcjaHuzB/Q==}
     engines: {node: '>=20'}
     cpu: [x64]
     os: [darwin]
 
-  '@eidos.space/graft-linux-arm64-gnu@0.3.21':
-    resolution: {integrity: sha512-GiLOWQbIutpQ3Z1SGRD8BFabWlbzDlJ4OLA3R9h07Y4S8T8ia35bJGfpV72u8LtGbISEiPFhwGdR2J/l9N/Opw==}
+  '@eidos.space/graft-linux-arm64-gnu@0.3.22':
+    resolution: {integrity: sha512-IQIkbdAglTqwqBlqGpYWqJ6V0F6V61ZO6g6dzj8Cmdesx8qb6U88YilUvJZX+tf/RbhnaRaw2QYIO2AMxA5FGw==}
     engines: {node: '>=20'}
     cpu: [arm64]
     os: [linux]
 
-  '@eidos.space/graft-linux-x64-gnu@0.3.21':
-    resolution: {integrity: sha512-ztGeSfurOljWGkWz3GFI+LJPgn48zbOmrJLcEB1QPPtp+Ut44W3IexWPHtAtXRDdaYMtqCeZbnqzj1+g7qSlsQ==}
+  '@eidos.space/graft-linux-x64-gnu@0.3.22':
+    resolution: {integrity: sha512-3UB+diVE/g5rHdhcX8AMxagZ7qyp4WTtP7/1a/J4+Q2LgWMzoTXeFHS0XCkoXK/9P7y2+Vstlr4/+XY4Z2eoLQ==}
     engines: {node: '>=20'}
     cpu: [x64]
     os: [linux]
@@ -1680,14 +1680,14 @@ packages:
     resolution: {integrity: sha512-/o98bDen6Bg2e1q9b8iJX/xkn0KmqI13Y1L6Wc72akEaho0xLl5o15jtSPnwvRR8+JfIRnJb2RynvZINM8ujVg==}
     engines: {node: '>=20'}
 
-  '@eidos.space/graft-win32-x64-msvc@0.3.21':
-    resolution: {integrity: sha512-nos/7tCRFjMeQNejlf2Lk05+Fipd4V+pndkZvvRVeRo6m05F98E1ovVJC4xsY5YDMKnA4Cv96jtqSuxz1KOI/A==}
+  '@eidos.space/graft-win32-x64-msvc@0.3.22':
+    resolution: {integrity: sha512-daY20Zgyu0g0btVkTOdoAaH2xiTvkCGb/m5cFxmCUZLQOA7+S1P/kBuZ/j7Qt35urFdfcczNsDT2BeuQjk8zgQ==}
     engines: {node: '>=20'}
     cpu: [x64]
     os: [win32]
 
-  '@eidos.space/graft@0.3.21':
-    resolution: {integrity: sha512-K3JLSrwqeP2wfQ5rzPxBv0F3n/0Pp/4h0GkvTjNWxGKbcnhQSGJLA1muePtTifKi37PuAqa8AA2FBjJvgO8N4Q==}
+  '@eidos.space/graft@0.3.22':
+    resolution: {integrity: sha512-tbzq+sPa6kag6fYcxA+wJr0429rqGAbEwnzKJ15fPA5XiHoX4YpuU3IjAiCoTV9jflwUyGQHmbw/yfqWQIjFOQ==}
     engines: {node: '>=20'}
 
   '@electron-internal/extract-zip@1.0.5':
@@ -10006,16 +10006,16 @@ snapshots:
       react: 18.3.1
       tslib: 2.8.1
 
-  '@eidos.space/graft-darwin-arm64@0.3.21':
+  '@eidos.space/graft-darwin-arm64@0.3.22':
     optional: true
 
-  '@eidos.space/graft-darwin-x64@0.3.21':
+  '@eidos.space/graft-darwin-x64@0.3.22':
     optional: true
 
-  '@eidos.space/graft-linux-arm64-gnu@0.3.21':
+  '@eidos.space/graft-linux-arm64-gnu@0.3.22':
     optional: true
 
-  '@eidos.space/graft-linux-x64-gnu@0.3.21':
+  '@eidos.space/graft-linux-x64-gnu@0.3.22':
     optional: true
 
   '@eidos.space/graft-remote-cloudflare@0.2.3(@cloudflare/workers-types@5.20260727.1)':
@@ -10030,16 +10030,16 @@ snapshots:
 
   '@eidos.space/graft-remote@0.2.3': {}
 
-  '@eidos.space/graft-win32-x64-msvc@0.3.21':
+  '@eidos.space/graft-win32-x64-msvc@0.3.22':
     optional: true
 
-  '@eidos.space/graft@0.3.21':
+  '@eidos.space/graft@0.3.22':
     optionalDependencies:
-      '@eidos.space/graft-darwin-arm64': 0.3.21
-      '@eidos.space/graft-darwin-x64': 0.3.21
-      '@eidos.space/graft-linux-arm64-gnu': 0.3.21
-      '@eidos.space/graft-linux-x64-gnu': 0.3.21
-      '@eidos.space/graft-win32-x64-msvc': 0.3.21
+      '@eidos.space/graft-darwin-arm64': 0.3.22
+      '@eidos.space/graft-darwin-x64': 0.3.22
+      '@eidos.space/graft-linux-arm64-gnu': 0.3.22
+      '@eidos.space/graft-linux-x64-gnu': 0.3.22
+      '@eidos.space/graft-win32-x64-msvc': 0.3.22
 
   '@electron-internal/extract-zip@1.0.5': {}
 


### PR DESCRIPTION
## Summary

- upgrade Eidos Lite to Graft 0.3.22
- add a macOS-to-Windows clone-equivalence regression gate
- prepare Eidos Lite 0.2.2 release metadata and notes

## Root cause

SQLite online backup rewrites the schema cookie and SQLite library version in page 1 on Windows. Graft 0.3.22 excludes these non-semantic bytes from clean-worktree comparison and rebuilds derived status caches.

## Validation

- Graft 0.3.22 five-platform package and Node 20/24 verification passed
- Eidos Lite typecheck passed
- node:sqlite adapter tests passed
- focused Graft client tests passed
- release-notes audit passed

The PR workflow is the release gate, with the Windows clone fixture as the critical regression proof.